### PR TITLE
Increase merge runs walltime

### DIFF
--- a/config/nextflow_pipeface.config
+++ b/config/nextflow_pipeface.config
@@ -25,7 +25,7 @@ process {
     withName: merge_runs {
         queue = 'normal'
         cpus = '1'
-        time = '3h'
+        time = '6h'
         memory = '4GB'
         module = 'samtools/1.19:htslib/1.16'
     }


### PR DESCRIPTION
Walltime will run out if the dataset is big enough