### PR TITLE
Implement deepvariant directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ depth_s2{{"Description: calculate alignment depth \n\n Main tools: Samtools \n\n
 depth_s3{{"Description: calculate alignment depth \n\n Main tools: Samtools \n\n Commands: samtools depth"}}
 depth_s4{{"Description: calculate alignment depth \n\n Main tools: Samtools \n\n Commands: samtools depth"}}
 
-snp_indel_calling_s1{{"Description: SNP/indel variant calling \n\n Main tools: Clair3 or DeepVariant (NVIDIA Parabricks) \n\n Commands: run_clair3.sh or pbrun deepvariant"}}
-snp_indel_calling_s2{{"Description: SNP/indel variant calling \n\n Main tools: Clair3 or DeepVariant (NVIDIA Parabricks) \n\n Commands: run_clair3.sh or pbrun deepvariant"}}
-snp_indel_calling_s3{{"Description: SNP/indel variant calling \n\n Main tools: Clair3 or DeepVariant (NVIDIA Parabricks) \n\n Commands: run_clair3.sh or pbrun deepvariant"}}
-snp_indel_calling_s4{{"Description: SNP/indel variant calling \n\n Main tools: Clair3 or DeepVariant (NVIDIA Parabricks) \n\n Commands: run_clair3.sh or pbrun deepvariant"}}
+snp_indel_calling_s1{{"Description: SNP/indel variant calling \n\n Main tools: Clair3 or DeepVariant \n\n Commands: run_clair3.sh or run_deepvariant"}}
+snp_indel_calling_s2{{"Description: SNP/indel variant calling \n\n Main tools: Clair3 or DeepVariant \n\n Commands: run_clair3.sh or run_deepvariant"}}
+snp_indel_calling_s3{{"Description: SNP/indel variant calling \n\n Main tools: Clair3 or DeepVariant \n\n Commands: run_clair3.sh or run_deepvariant"}}
+snp_indel_calling_s4{{"Description: SNP/indel variant calling \n\n Main tools: Clair3 or DeepVariant \n\n Commands: run_clair3.sh or run_deepvariant"}}
 
 snp_indel_phasing_s1{{"Description: SNP/indel phasing \n\n Main tools: WhatsHap \n\n Commands: whatshap phase"}}
 snp_indel_phasing_s2{{"Description: SNP/indel phasing \n\n Main tools: WhatsHap \n\n Commands: whatshap phase"}}
@@ -107,7 +107,7 @@ alignment_s4-.->haplotagging_s4
 ## Main tools
 
 - [Minimap2](https://github.com/lh3/minimap2)
-- [Clair3](https://github.com/HKU-BAL/Clair3) OR [DeepVariant](https://github.com/google/deepvariant) (wrapped in [NVIDIA Parabricks](https://docs.nvidia.com/clara/parabricks/latest/))
+- [Clair3](https://github.com/HKU-BAL/Clair3) OR [DeepVariant](https://github.com/google/deepvariant)
 - [WhatsHap](https://github.com/whatshap/whatshap)
 - [Sniffles2](https://github.com/fritzsedlazeck/Sniffles) AND/OR [cuteSV](https://github.com/tjiangHIT/cuteSV)
 - [Samtools](https://github.com/samtools/samtools)

--- a/config/nextflow_pipeface.config
+++ b/config/nextflow_pipeface.config
@@ -5,7 +5,7 @@ process {
     project = 'kr68'
     storage = 'gdata/if89+scratch/kr68+gdata/kr68+gdata/ox63'
     // provide proper access to if89 environmental modules
-    beforeScript = 'module use -a /g/data/if89/apps/modulefiles'
+    beforeScript = 'module use -a /g/data/if89/apps/modulefiles && module use -a /g/data/if89/shpcroot/modules'
 
     withName: scrape_settings {
         queue = 'normal'
@@ -58,9 +58,10 @@ process {
         queue = 'gpuvolta'
         cpus = '24'
         gpus = '2'
-        time = '6h'
-        memory = '180GB'
-        module = 'parabricks/4.2.1:htslib/1.16'
+        time = '8h'
+        memory = '192GB'
+        disk = '80GB'
+        module = 'singularity'
     }
 
     withName: 'whatshap_phase_clair3|whatshap_phase_dv|whatshap_haplotag' {

--- a/docs/run_on_nci.md
+++ b/docs/run_on_nci.md
@@ -9,7 +9,7 @@
     - [Clair3 models](#clair3-models)
       - [ONT](#ont)
       - [Pacbio HiFi revio](#pacbio-hifi-revio)
-  - [3. Modify in_data.csv](#3-modify-in_datacsv)
+  - [3. Modify in\_data.csv](#3-modify-in_datacsv)
   - [4. Modify nextflow\_pipeface.config](#4-modify-nextflow_pipefaceconfig)
   - [5. Modify parameters\_pipeface.json](#5-modify-parameters_pipefacejson)
   - [6. Get pipeline dependencies](#6-get-pipeline-dependencies)


### PR DESCRIPTION
Implement deepvariant directly rather than using deepvariant implemented by clara parabricks. This will allow us to use a newer version of deepvariant and remove one layer of software (clara parabricks). Most importantly, it allows us the remove the requirement that clara parabricks deepvariant enforces; a modification to the read groups in the input aligned bam. So basically we can leave read groups alone as well allow the pipeline to proceed when the input uBAM doesn't contain any read groups.