### PR TITLE
Mosdepth

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 Pipefaceee.
 
-Nextflow pipeline to align, variant call (SNP's, indels's, SV's) and phase long read [ONT](https://nanoporetech.com/) and/or [pacbio](https://www.pacb.com/) HiFi data.
+Nextflow pipeline to align, variant call (SNP's, indels's, SV's), phase and annotate (optional) long read [ONT](https://nanoporetech.com/) and/or [pacbio](https://www.pacb.com/) HiFi data.
 
-There currently exists tools and workflows which align, variant call and phase ONT/pacbio HiFi data, but pipeface serves as a central workflow to process long read data. Pipeface's future hold's STR, CNV and tandem repeat calling, as well as the analysis of cohorts.
+There currently exists tools and workflows which align, variant call, phase and annotate ONT/pacbio HiFi data, but pipeface serves as a central workflow to process long read data. Pipeface's future hold's STR, CNV and tandem repeat calling, as well as the analysis of cohorts.
 
 <p align="center">
     <img src="./images/pipeface.png">
@@ -23,12 +23,14 @@ alignment{{"bam to fastq conversion (if needed), alignment, sorting"}}
 depth{{"Calculate alignment depth"}}
 snp_indel_calling{{"SNP/indel variant calling"}}
 snp_indel_phasing{{"SNP/indel phasing"}}
+snp_indel_annotation{{"SNP/indel annotation (optional)"}}
 haplotagging{{"Haplotagging bams"}}
 sv_calling{{"Structural variant calling"}}
 
 input_data-.->merging-.->alignment-.->snp_indel_calling-.->snp_indel_phasing-.->haplotagging-.->sv_calling
 alignment-.->depth
 alignment-.->haplotagging
+snp_indel_phasing-.->snp_indel_annotation
 
 ```
 
@@ -68,6 +70,11 @@ snp_indel_phasing_s2{{"Description: SNP/indel phasing <br><br> Main tools: Whats
 snp_indel_phasing_s3{{"Description: SNP/indel phasing <br><br> Main tools: WhatsHap <br><br> Commands: whatshap phase"}}
 snp_indel_phasing_s4{{"Description: SNP/indel phasing <br><br> Main tools: WhatsHap <br><br> Commands: whatshap phase"}}
 
+snp_indel_annotation_s1{{"Description: SNP/indel annotation (optional) <br><br> Main tools: ensembl-vep <br><br> Commands: vep"}}
+snp_indel_annotation_s2{{"Description: SNP/indel annotation (optional) <br><br> Main tools: ensembl-vep <br><br> Commands: vep"}}
+snp_indel_annotation_s3{{"Description: SNP/indel annotation (optional) <br><br> Main tools: ensembl-vep <br><br> Commands: vep"}}
+snp_indel_annotation_s4{{"Description: SNP/indel annotation (optional) <br><br> Main tools: ensembl-vep <br><br> Commands: vep"}}
+
 haplotagging_s1{{"Description: haplotagging bams <br><br> Main tools: WhatsHap <br><br> Commands: whatshap haplotag"}}
 haplotagging_s2{{"Description: haplotagging bams <br><br> Main tools: WhatsHap <br><br> Commands: whatshap haplotag"}}
 haplotagging_s3{{"Description: haplotagging bams <br><br> Main tools: WhatsHap <br><br> Commands: whatshap haplotag"}}
@@ -96,6 +103,11 @@ alignment_s2-.->haplotagging_s2
 alignment_s3-.->haplotagging_s3
 alignment_s4-.->haplotagging_s4
 
+snp_indel_phasing_s1-.->snp_indel_annotation_s1
+snp_indel_phasing_s2-.->snp_indel_annotation_s2
+snp_indel_phasing_s3-.->snp_indel_annotation_s3
+snp_indel_phasing_s4-.->snp_indel_annotation_s4
+
 ```
 
 ## Main analyses
@@ -111,6 +123,7 @@ alignment_s4-.->haplotagging_s4
 - [WhatsHap](https://github.com/whatshap/whatshap)
 - [Sniffles2](https://github.com/fritzsedlazeck/Sniffles) and/or [cuteSV](https://github.com/tjiangHIT/cuteSV)
 - [Samtools](https://github.com/samtools/samtools)
+- [ensembl-vep](https://github.com/Ensembl/ensembl-vep)
 
 ## Main input files
 
@@ -129,19 +142,20 @@ alignment_s4-.->haplotagging_s4
 
 - Aligned, sorted and haplotagged bam
 - Clair3 or DeepVariant phased SNP/indel VCF file
-- Clair3 or DeepVariant SNP/indel gVCF file
+- Annotated Clair3 or DeepVariant phased SNP/indel VCF file (optional)
 - Phased Sniffles2 and/or un-phased cuteSV SV VCF file
 
 ## Assumptions
 
 - Running pipeline on Australia's [National Computational Infrastructure (NCI)](https://nci.org.au/)
 - Access to if89 project on [National Computational Infrastructure (NCI)](https://nci.org.au/)
+- Access to xy86 project on [National Computational Infrastructure (NCI)](https://nci.org.au/) (if running variant annotation)
 - Access to pipeline dependencies:
     - [Nextflow and it's java dependency](https://nf-co.re/docs/usage/installation). Validated to run on:
         - Nextflow 24.04.1
         - Java 17.0.2
 
-*[See the list of software and their versions used by this version of pipeface](./docs/software_versions.txt)* (assuming the default [nextflow_pipeface.config](./config/nextflow_pipeface.config) file is used).
+*[See the list of software and their versions used by this version of pipeface](./docs/software_versions.txt) as well as the [list of variant databases and their versions](./docs/database_versions.txt) if variant annotation is carried out (assuming the default [nextflow_pipeface.config](./config/nextflow_pipeface.config) file is used).*
 
 ## Run it!
 
@@ -150,3 +164,4 @@ See a walkthrough for how to [run pipeface on NCI](./docs/run_on_nci.md).
 ## Credit
 
 This is a highly collaborative project, with many contributions from the [Genomic Technologies Lab](https://www.garvan.org.au/research/labs-groups/genomic-technologies-lab). Notably, Dr Andre Reis and Dr Ira Deveson are closely involved in the development of this pipeline. The installation and hosting of software used in this pipeline has been supported by the [Australian BioCommons Tools and Workflows project (if89)](https://australianbiocommons.github.io/ables/if89/).
+

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 Pipefaceee.
 
-Nextflow pipeline to align, variant call (SNP's, indels's, SV's), phase and annotate (optional - hg38 only) long read [ONT](https://nanoporetech.com/) and/or [pacbio](https://www.pacb.com/) HiFi data.
+Nextflow pipeline to align, variant call (SNP's, indels's, SV's), phase and optionally annotate long read [ONT](https://nanoporetech.com/) and/or [pacbio](https://www.pacb.com/) HiFi data.
 
-There currently exists tools and workflows which align, variant call, phase and annotate ONT/pacbio HiFi data, but pipeface serves as a central workflow to process long read data. Pipeface's future hold's STR, CNV and tandem repeat calling, as well as the analysis of cohorts.
+There currently exists tools and workflows that undertake comparable analyses, but pipeface serves as a central workflow to process long read data (both ONT and pacbio HiFi data). Pipeface's future hold's STR, CNV and tandem repeat calling, as well as the analysis of cohorts.
 
 <p align="center">
     <img src="./images/pipeface.png">
@@ -142,7 +142,7 @@ snp_indel_phasing_s4-.->snp_indel_annotation_s4
 
 - Aligned, sorted and haplotagged bam
 - Clair3 or DeepVariant phased SNP/indel VCF file
-- Annotated Clair3 or DeepVariant phased SNP/indel VCF file (optional - hg38 only)
+- Clair3 or DeepVariant phased and annotated SNP/indel VCF file (optional - hg38 only)
 - Phased Sniffles2 and/or un-phased cuteSV SV VCF file
 
 ## Assumptions
@@ -163,5 +163,5 @@ See a walkthrough for how to [run pipeface on NCI](./docs/run_on_nci.md).
 
 ## Credit
 
-This is a highly collaborative project, with many contributions from the [Genomic Technologies Lab](https://www.garvan.org.au/research/labs-groups/genomic-technologies-lab). Notably, Dr Andre Reis and Dr Ira Deveson are closely involved in the development of this pipeline. The installation and hosting of software used in this pipeline has been supported by the [Australian BioCommons Tools and Workflows project (if89)](https://australianbiocommons.github.io/ables/if89/).
+This is a highly collaborative project, with many contributions from the [Genomic Technologies Lab](https://www.garvan.org.au/research/labs-groups/genomic-technologies-lab). Notably, Dr Andre Reis and Dr Ira Deveson are closely involved in the development of this pipeline. The installation and hosting of software used in this pipeline has and continues to be supported by the [Australian BioCommons Tools and Workflows project (if89)](https://australianbiocommons.github.io/ables/if89/).
 

--- a/README.md
+++ b/README.md
@@ -40,50 +40,45 @@ snp_indel_phasing-.->snp_indel_annotation
 %%{init: {'theme':'dark'}}%%
 flowchart LR
 
-ont_data_f1("Sample 1 <br><br> Input data: <br> ONT fastq.gz")
-ont_data_f2("Sample 1 <br><br> Input data: <br> ONT fastq.gz")
-pacbio_data_f3("Sample 2 <br><br> Input data: <br> Pacbio HiFi uBAM")
-pacbio_data_f4("Sample 2 <br><br> Input data: <br> Pacbio HiFi uBAM")
-ont_data_f5("Sample 3 <br><br> Input data: <br> ONT fastq")
-ont_data_f6("Sample 4 <br><br> Input data: <br> ONT uBAM")
+ont_data_f1("Sample 1 \n\n Input data: \n\n ONT fastq.gz")
+ont_data_f2("Sample 1 \n\n Input data: \n\n ONT fastq.gz")
+pacbio_data_f3("Sample 2 \n\n Input data: \n\n Pacbio HiFi uBAM")
+pacbio_data_f4("Sample 2 \n\n Input data: \n\n Pacbio HiFi uBAM")
+ont_data_f5("Sample 3 \n\n Input data: \n\n ONT fastq")
+ont_data_f6("Sample 4 \n\n Input data: \n\n ONT uBAM")
 
-merging_m1{{"Description: merge runs <br><br> Main tools: GNU coreutils <br><br> Commands: cat"}}
-merging_m2{{"Description: merge runs <br><br> Main tools: Samtools <br><br> Commands: samtools merge"}}
+merging_m1{{"Description: merge runs \n\n Main tools: GNU coreutils \n\n Commands: cat"}}
+merging_m2{{"Description: merge runs \n\n Main tools: Samtools \n\n Commands: samtools merge"}}
 
-alignment_s1{{"Description: alignment, sorting <br><br> Main tools: Minimap2 and Samtools <br><br> Commands: minimap2 and samtools sort"}}
-alignment_s2{{"Description: alignment, sorting <br><br> Main tools: Minimap2 and Samtools <br><br> Commands: minimap2 and samtools sort"}}
-alignment_s3{{"Description: bam to fastq conversion, alignment, sorting <br><br> Main tools: Minimap2 and Samtools <br><br> Commands: minimap2 and samtools sort"}}
-alignment_s4{{"Description: bam to fastq conversion, alignment, sorting <br><br> Main tools: Minimap2 and Samtools <br><br> Commands: minimap2 and samtools sort"}}
+alignment_s1{{"Description: alignment, sorting \n\n Main tools: Minimap2 and Samtools \n\n Commands: minimap2 and samtools sort"}}
+alignment_s2{{"Description: alignment, sorting \n\n Main tools: Minimap2 and Samtools \n\n Commands: minimap2 and samtools sort"}}
+alignment_s3{{"Description: bam to fastq conversion, alignment, sorting \n\n Main tools: Minimap2 and Samtools \n\n Commands: minimap2 and samtools sort"}}
+alignment_s4{{"Description: bam to fastq conversion, alignment, sorting \n\n Main tools: Minimap2 and Samtools \n\n Commands: minimap2 and samtools sort"}}
 
-depth_s1{{"Description: calculate alignment depth <br><br> Main tools: Samtools <br><br> Commands: samtools depth"}}
-depth_s2{{"Description: calculate alignment depth <br><br> Main tools: Samtools <br><br> Commands: samtools depth"}}
-depth_s3{{"Description: calculate alignment depth <br><br> Main tools: Samtools <br><br> Commands: samtools depth"}}
-depth_s4{{"Description: calculate alignment depth <br><br> Main tools: Samtools <br><br> Commands: samtools depth"}}
+depth_s1{{"Description: calculate alignment depth \n\n Main tools: Samtools \n\n Commands: samtools depth"}}
+depth_s2{{"Description: calculate alignment depth \n\n Main tools: Samtools \n\n Commands: samtools depth"}}
+depth_s3{{"Description: calculate alignment depth \n\n Main tools: Samtools \n\n Commands: samtools depth"}}
+depth_s4{{"Description: calculate alignment depth \n\n Main tools: Samtools \n\n Commands: samtools depth"}}
 
-snp_indel_calling_s1{{"Description: SNP/indel variant calling <br><br> Main tools: Clair3 or DeepVariant (NVIDIA Parabricks) <br><br> Commands: run_clair3.sh or pbrun deepvariant"}}
-snp_indel_calling_s2{{"Description: SNP/indel variant calling <br><br> Main tools: Clair3 or DeepVariant (NVIDIA Parabricks) <br><br> Commands: run_clair3.sh or pbrun deepvariant"}}
-snp_indel_calling_s3{{"Description: SNP/indel variant calling <br><br> Main tools: Clair3 or DeepVariant (NVIDIA Parabricks) <br><br> Commands: run_clair3.sh or pbrun deepvariant"}}
-snp_indel_calling_s4{{"Description: SNP/indel variant calling <br><br> Main tools: Clair3 or DeepVariant (NVIDIA Parabricks) <br><br> Commands: run_clair3.sh or pbrun deepvariant"}}
+snp_indel_calling_s1{{"Description: SNP/indel variant calling \n\n Main tools: Clair3 or DeepVariant \n\n Commands: run_clair3.sh or run_deepvariant"}}
+snp_indel_calling_s2{{"Description: SNP/indel variant calling \n\n Main tools: Clair3 or DeepVariant \n\n Commands: run_clair3.sh or run_deepvariant"}}
+snp_indel_calling_s3{{"Description: SNP/indel variant calling \n\n Main tools: Clair3 or DeepVariant \n\n Commands: run_clair3.sh or run_deepvariant"}}
+snp_indel_calling_s4{{"Description: SNP/indel variant calling \n\n Main tools: Clair3 or DeepVariant \n\n Commands: run_clair3.sh or run_deepvariant"}}
 
-snp_indel_phasing_s1{{"Description: SNP/indel phasing <br><br> Main tools: WhatsHap <br><br> Commands: whatshap phase"}}
-snp_indel_phasing_s2{{"Description: SNP/indel phasing <br><br> Main tools: WhatsHap <br><br> Commands: whatshap phase"}}
-snp_indel_phasing_s3{{"Description: SNP/indel phasing <br><br> Main tools: WhatsHap <br><br> Commands: whatshap phase"}}
-snp_indel_phasing_s4{{"Description: SNP/indel phasing <br><br> Main tools: WhatsHap <br><br> Commands: whatshap phase"}}
+snp_indel_phasing_s1{{"Description: SNP/indel phasing \n\n Main tools: WhatsHap \n\n Commands: whatshap phase"}}
+snp_indel_phasing_s2{{"Description: SNP/indel phasing \n\n Main tools: WhatsHap \n\n Commands: whatshap phase"}}
+snp_indel_phasing_s3{{"Description: SNP/indel phasing \n\n Main tools: WhatsHap \n\n Commands: whatshap phase"}}
+snp_indel_phasing_s4{{"Description: SNP/indel phasing \n\n Main tools: WhatsHap \n\n Commands: whatshap phase"}}
 
-snp_indel_annotation_s1{{"Description: SNP/indel annotation (optional) <br><br> Main tools: ensembl-vep <br><br> Commands: vep"}}
-snp_indel_annotation_s2{{"Description: SNP/indel annotation (optional) <br><br> Main tools: ensembl-vep <br><br> Commands: vep"}}
-snp_indel_annotation_s3{{"Description: SNP/indel annotation (optional) <br><br> Main tools: ensembl-vep <br><br> Commands: vep"}}
-snp_indel_annotation_s4{{"Description: SNP/indel annotation (optional) <br><br> Main tools: ensembl-vep <br><br> Commands: vep"}}
+haplotagging_s1{{"Description: haplotagging bams \n\n Main tools: WhatsHap \n\n Commands: whatshap haplotag"}}
+haplotagging_s2{{"Description: haplotagging bams \n\n Main tools: WhatsHap \n\n Commands: whatshap haplotag"}}
+haplotagging_s3{{"Description: haplotagging bams \n\n Main tools: WhatsHap \n\n Commands: whatshap haplotag"}}
+haplotagging_s4{{"Description: haplotagging bams \n\n Main tools: WhatsHap \n\n Commands: whatshap haplotag"}}
 
-haplotagging_s1{{"Description: haplotagging bams <br><br> Main tools: WhatsHap <br><br> Commands: whatshap haplotag"}}
-haplotagging_s2{{"Description: haplotagging bams <br><br> Main tools: WhatsHap <br><br> Commands: whatshap haplotag"}}
-haplotagging_s3{{"Description: haplotagging bams <br><br> Main tools: WhatsHap <br><br> Commands: whatshap haplotag"}}
-haplotagging_s4{{"Description: haplotagging bams <br><br> Main tools: WhatsHap <br><br> Commands: whatshap haplotag"}}
-
-sv_calling_s1{{"Description: structural variant calling <br><br> Main tools: Sniffles2 and/or cuteSV <br><br> Commands: sniffles and/or cuteSV"}}
-sv_calling_s2{{"Description: structural variant calling <br><br> Main tools: Sniffles2 and/or cuteSV <br><br> Commands: sniffles and/or cuteSV"}}
-sv_calling_s3{{"Description: structural variant calling <br><br> Main tools: Sniffles2 and/or cuteSV <br><br> Commands: sniffles and/or cuteSV"}}
-sv_calling_s4{{"Description: structural variant calling <br><br> Main tools: Sniffles2 and/or cuteSV <br><br> Commands: sniffles and/or cuteSV"}}
+sv_calling_s1{{"Description: structural variant calling \n\n Main tools: Sniffles2 and/or cuteSV \n\n Commands: sniffles and/or cuteSV"}}
+sv_calling_s2{{"Description: structural variant calling \n\n Main tools: Sniffles2 and/or cuteSV \n\n Commands: sniffles and/or cuteSV"}}
+sv_calling_s3{{"Description: structural variant calling \n\n Main tools: Sniffles2 and/or cuteSV \n\n Commands: sniffles and/or cuteSV"}}
+sv_calling_s4{{"Description: structural variant calling \n\n Main tools: Sniffles2 and/or cuteSV \n\n Commands: sniffles and/or cuteSV"}}
 
 ont_data_f1-.->merging_m1-.->alignment_s1-.->snp_indel_calling_s1-.->snp_indel_phasing_s1-.->haplotagging_s1-.->sv_calling_s1
 ont_data_f2-.->merging_m1
@@ -119,7 +114,7 @@ snp_indel_phasing_s4-.->snp_indel_annotation_s4
 ## Main tools
 
 - [Minimap2](https://github.com/lh3/minimap2)
-- [Clair3](https://github.com/HKU-BAL/Clair3) or [DeepVariant](https://github.com/google/deepvariant) (wrapped in [NVIDIA Parabricks](https://docs.nvidia.com/clara/parabricks/latest/))
+- [Clair3](https://github.com/HKU-BAL/Clair3) or [DeepVariant](https://github.com/google/deepvariant)
 - [WhatsHap](https://github.com/whatshap/whatshap)
 - [Sniffles2](https://github.com/fritzsedlazeck/Sniffles) and/or [cuteSV](https://github.com/tjiangHIT/cuteSV)
 - [Samtools](https://github.com/samtools/samtools)

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ There currently exists tools and workflows which align, variant call and phase O
 
 ## Workflow
 
-### Overview
-
 ```mermaid
 %%{init: {'theme':'dark'}}%%
 flowchart LR
@@ -142,6 +140,8 @@ alignment_s4-.->haplotagging_s4
     - [Nextflow and it's java dependency](https://nf-co.re/docs/usage/installation). Validated to run on:
         - Nextflow 24.04.1
         - Java 17.0.2
+
+*[See the list of software and their versions used by this version of pipeface](./docs/software_versions.txt)* (assuming the default [nextflow_pipeface.config](./config/nextflow_pipeface.config) file is used).
 
 ## Run it!
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ snp_indel_phasing_s4-.->snp_indel_annotation_s4
 - Indexed reference genome
 - Clair3 models (if running Clair3)
 - [DeepVariant GPU 1.6.1 docker container](https://hub.docker.com/layers/google/deepvariant/1.6.1-gpu/images/sha256-7929c55106d3739daa18d52802913c43af4ca2879db29656056f59005d1d46cb?context=explore) pulled via singularity (if running DeepVariant)
+- [mosdepth 0.3.9 binary](https://github.com/brentp/mosdepth/releases/tag/v0.3.9) (if running depth calculation)
 
 ### Optional
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Pipefaceee.
 
 Nextflow pipeline to align, variant call (SNP's, indels's, SV's) and phase long read [ONT](https://nanoporetech.com/) and/or [pacbio](https://www.pacb.com/) HiFi data.
 
+There currently exists tools and workflows which align, variant call and phase ONT/pacbio HiFi data, but pipeface serves as a central workflow to process long read data. Pipeface's future hold's STR, CNV and tandem repeat calling, as well as the analysis of cohorts.
+
 <p align="center">
     <img src="./images/pipeface.png">
 
@@ -17,7 +19,7 @@ Nextflow pipeline to align, variant call (SNP's, indels's, SV's) and phase long 
 %%{init: {'theme':'dark'}}%%
 flowchart LR
 
-input_data("Input data: \n\n ONT fastq.gz \n and/or \n ONT fastq \n and/or \n ONT uBAM \n and/or \n pacbio HiFi uBAM")
+input_data("Input data: <br><br> ONT fastq.gz <br> and/or <br> ONT fastq <br> and/or <br> ONT uBAM <br> and/or <br> pacbio HiFi uBAM")
 merging{{"Merge runs (if needed)"}}
 alignment{{"bam to fastq conversion (if needed), alignment, sorting"}}
 depth{{"Calculate alignment depth"}}
@@ -38,45 +40,45 @@ alignment-.->haplotagging
 %%{init: {'theme':'dark'}}%%
 flowchart LR
 
-ont_data_f1("Sample 1 \n\n Input data: \n\n ONT fastq.gz")
-ont_data_f2("Sample 1 \n\n Input data: \n\n ONT fastq.gz")
-pacbio_data_f3("Sample 2 \n\n Input data: \n\n Pacbio HiFi uBAM")
-pacbio_data_f4("Sample 2 \n\n Input data: \n\n Pacbio HiFi uBAM")
-ont_data_f5("Sample 3 \n\n Input data: \n\n ONT fastq")
-ont_data_f6("Sample 4 \n\n Input data: \n\n ONT uBAM")
+ont_data_f1("Sample 1 <br><br> Input data: <br> ONT fastq.gz")
+ont_data_f2("Sample 1 <br><br> Input data: <br> ONT fastq.gz")
+pacbio_data_f3("Sample 2 <br><br> Input data: <br> Pacbio HiFi uBAM")
+pacbio_data_f4("Sample 2 <br><br> Input data: <br> Pacbio HiFi uBAM")
+ont_data_f5("Sample 3 <br><br> Input data: <br> ONT fastq")
+ont_data_f6("Sample 4 <br><br> Input data: <br> ONT uBAM")
 
-merging_m1{{"Description: merge runs \n\n Main tools: GNU coreutils \n\n Commands: cat"}}
-merging_m2{{"Description: merge runs \n\n Main tools: Samtools \n\n Commands: samtools merge"}}
+merging_m1{{"Description: merge runs <br><br> Main tools: GNU coreutils <br><br> Commands: cat"}}
+merging_m2{{"Description: merge runs <br><br> Main tools: Samtools <br><br> Commands: samtools merge"}}
 
-alignment_s1{{"Description: alignment, sorting \n\n Main tools: Minimap2 and Samtools \n\n Commands: minimap2 and samtools sort"}}
-alignment_s2{{"Description: alignment, sorting \n\n Main tools: Minimap2 and Samtools \n\n Commands: minimap2 and samtools sort"}}
-alignment_s3{{"Description: bam to fastq conversion, alignment, sorting \n\n Main tools: Minimap2 and Samtools \n\n Commands: minimap2 and samtools sort"}}
-alignment_s4{{"Description: bam to fastq conversion, alignment, sorting \n\n Main tools: Minimap2 and Samtools \n\n Commands: minimap2 and samtools sort"}}
+alignment_s1{{"Description: alignment, sorting <br><br> Main tools: Minimap2 and Samtools <br><br> Commands: minimap2 and samtools sort"}}
+alignment_s2{{"Description: alignment, sorting <br><br> Main tools: Minimap2 and Samtools <br><br> Commands: minimap2 and samtools sort"}}
+alignment_s3{{"Description: bam to fastq conversion, alignment, sorting <br><br> Main tools: Minimap2 and Samtools <br><br> Commands: minimap2 and samtools sort"}}
+alignment_s4{{"Description: bam to fastq conversion, alignment, sorting <br><br> Main tools: Minimap2 and Samtools <br><br> Commands: minimap2 and samtools sort"}}
 
-depth_s1{{"Description: calculate alignment depth \n\n Main tools: Samtools \n\n Commands: samtools depth"}}
-depth_s2{{"Description: calculate alignment depth \n\n Main tools: Samtools \n\n Commands: samtools depth"}}
-depth_s3{{"Description: calculate alignment depth \n\n Main tools: Samtools \n\n Commands: samtools depth"}}
-depth_s4{{"Description: calculate alignment depth \n\n Main tools: Samtools \n\n Commands: samtools depth"}}
+depth_s1{{"Description: calculate alignment depth <br><br> Main tools: Samtools <br><br> Commands: samtools depth"}}
+depth_s2{{"Description: calculate alignment depth <br><br> Main tools: Samtools <br><br> Commands: samtools depth"}}
+depth_s3{{"Description: calculate alignment depth <br><br> Main tools: Samtools <br><br> Commands: samtools depth"}}
+depth_s4{{"Description: calculate alignment depth <br><br> Main tools: Samtools <br><br> Commands: samtools depth"}}
 
-snp_indel_calling_s1{{"Description: SNP/indel variant calling \n\n Main tools: Clair3 or DeepVariant (NVIDIA Parabricks) \n\n Commands: run_clair3.sh or pbrun deepvariant"}}
-snp_indel_calling_s2{{"Description: SNP/indel variant calling \n\n Main tools: Clair3 or DeepVariant (NVIDIA Parabricks) \n\n Commands: run_clair3.sh or pbrun deepvariant"}}
-snp_indel_calling_s3{{"Description: SNP/indel variant calling \n\n Main tools: Clair3 or DeepVariant (NVIDIA Parabricks) \n\n Commands: run_clair3.sh or pbrun deepvariant"}}
-snp_indel_calling_s4{{"Description: SNP/indel variant calling \n\n Main tools: Clair3 or DeepVariant (NVIDIA Parabricks) \n\n Commands: run_clair3.sh or pbrun deepvariant"}}
+snp_indel_calling_s1{{"Description: SNP/indel variant calling <br><br> Main tools: Clair3 or DeepVariant (NVIDIA Parabricks) <br><br> Commands: run_clair3.sh or pbrun deepvariant"}}
+snp_indel_calling_s2{{"Description: SNP/indel variant calling <br><br> Main tools: Clair3 or DeepVariant (NVIDIA Parabricks) <br><br> Commands: run_clair3.sh or pbrun deepvariant"}}
+snp_indel_calling_s3{{"Description: SNP/indel variant calling <br><br> Main tools: Clair3 or DeepVariant (NVIDIA Parabricks) <br><br> Commands: run_clair3.sh or pbrun deepvariant"}}
+snp_indel_calling_s4{{"Description: SNP/indel variant calling <br><br> Main tools: Clair3 or DeepVariant (NVIDIA Parabricks) <br><br> Commands: run_clair3.sh or pbrun deepvariant"}}
 
-snp_indel_phasing_s1{{"Description: SNP/indel phasing \n\n Main tools: WhatsHap \n\n Commands: whatshap phase"}}
-snp_indel_phasing_s2{{"Description: SNP/indel phasing \n\n Main tools: WhatsHap \n\n Commands: whatshap phase"}}
-snp_indel_phasing_s3{{"Description: SNP/indel phasing \n\n Main tools: WhatsHap \n\n Commands: whatshap phase"}}
-snp_indel_phasing_s4{{"Description: SNP/indel phasing \n\n Main tools: WhatsHap \n\n Commands: whatshap phase"}}
+snp_indel_phasing_s1{{"Description: SNP/indel phasing <br><br> Main tools: WhatsHap <br><br> Commands: whatshap phase"}}
+snp_indel_phasing_s2{{"Description: SNP/indel phasing <br><br> Main tools: WhatsHap <br><br> Commands: whatshap phase"}}
+snp_indel_phasing_s3{{"Description: SNP/indel phasing <br><br> Main tools: WhatsHap <br><br> Commands: whatshap phase"}}
+snp_indel_phasing_s4{{"Description: SNP/indel phasing <br><br> Main tools: WhatsHap <br><br> Commands: whatshap phase"}}
 
-haplotagging_s1{{"Description: haplotagging bams \n\n Main tools: WhatsHap \n\n Commands: whatshap haplotag"}}
-haplotagging_s2{{"Description: haplotagging bams \n\n Main tools: WhatsHap \n\n Commands: whatshap haplotag"}}
-haplotagging_s3{{"Description: haplotagging bams \n\n Main tools: WhatsHap \n\n Commands: whatshap haplotag"}}
-haplotagging_s4{{"Description: haplotagging bams \n\n Main tools: WhatsHap \n\n Commands: whatshap haplotag"}}
+haplotagging_s1{{"Description: haplotagging bams <br><br> Main tools: WhatsHap <br><br> Commands: whatshap haplotag"}}
+haplotagging_s2{{"Description: haplotagging bams <br><br> Main tools: WhatsHap <br><br> Commands: whatshap haplotag"}}
+haplotagging_s3{{"Description: haplotagging bams <br><br> Main tools: WhatsHap <br><br> Commands: whatshap haplotag"}}
+haplotagging_s4{{"Description: haplotagging bams <br><br> Main tools: WhatsHap <br><br> Commands: whatshap haplotag"}}
 
-sv_calling_s1{{"Description: structural variant calling \n\n Main tools: Sniffles2 and/or cuteSV \n\n Commands: sniffles and/or cuteSV"}}
-sv_calling_s2{{"Description: structural variant calling \n\n Main tools: Sniffles2 and/or cuteSV \n\n Commands: sniffles and/or cuteSV"}}
-sv_calling_s3{{"Description: structural variant calling \n\n Main tools: Sniffles2 and/or cuteSV \n\n Commands: sniffles and/or cuteSV"}}
-sv_calling_s4{{"Description: structural variant calling \n\n Main tools: Sniffles2 and/or cuteSV \n\n Commands: sniffles and/or cuteSV"}}
+sv_calling_s1{{"Description: structural variant calling <br><br> Main tools: Sniffles2 and/or cuteSV <br><br> Commands: sniffles and/or cuteSV"}}
+sv_calling_s2{{"Description: structural variant calling <br><br> Main tools: Sniffles2 and/or cuteSV <br><br> Commands: sniffles and/or cuteSV"}}
+sv_calling_s3{{"Description: structural variant calling <br><br> Main tools: Sniffles2 and/or cuteSV <br><br> Commands: sniffles and/or cuteSV"}}
+sv_calling_s4{{"Description: structural variant calling <br><br> Main tools: Sniffles2 and/or cuteSV <br><br> Commands: sniffles and/or cuteSV"}}
 
 ont_data_f1-.->merging_m1-.->alignment_s1-.->snp_indel_calling_s1-.->snp_indel_phasing_s1-.->haplotagging_s1-.->sv_calling_s1
 ont_data_f2-.->merging_m1
@@ -107,9 +109,9 @@ alignment_s4-.->haplotagging_s4
 ## Main tools
 
 - [Minimap2](https://github.com/lh3/minimap2)
-- [Clair3](https://github.com/HKU-BAL/Clair3) OR [DeepVariant](https://github.com/google/deepvariant) (wrapped in [NVIDIA Parabricks](https://docs.nvidia.com/clara/parabricks/latest/))
+- [Clair3](https://github.com/HKU-BAL/Clair3) or [DeepVariant](https://github.com/google/deepvariant) (wrapped in [NVIDIA Parabricks](https://docs.nvidia.com/clara/parabricks/latest/))
 - [WhatsHap](https://github.com/whatshap/whatshap)
-- [Sniffles2](https://github.com/fritzsedlazeck/Sniffles) AND/OR [cuteSV](https://github.com/tjiangHIT/cuteSV)
+- [Sniffles2](https://github.com/fritzsedlazeck/Sniffles) and/or [cuteSV](https://github.com/tjiangHIT/cuteSV)
 - [Samtools](https://github.com/samtools/samtools)
 
 ## Main input files
@@ -139,8 +141,12 @@ alignment_s4-.->haplotagging_s4
 - Access to pipeline dependencies:
     - [Nextflow and it's java dependency](https://nf-co.re/docs/usage/installation). Validated to run on:
         - Nextflow 24.04.1
-        - Java version 17.0.2
+        - Java 17.0.2
 
 ## Run it!
 
 See a walkthrough for how to [run pipeface on NCI](./docs/run_on_nci.md).
+
+## Credit
+
+This is a highly collaborative project, with many contributions from the [Genomic Technologies Lab](https://www.garvan.org.au/research/labs-groups/genomic-technologies-lab). Notably, Dr Andre Reis and Dr Ira Deveson are closely involved in the development of this pipeline. The installation and hosting of software used in this pipeline has been supported by the [Australian BioCommons Tools and Workflows project (if89)](https://australianbiocommons.github.io/ables/if89/).

--- a/README.md
+++ b/README.md
@@ -40,50 +40,50 @@ snp_indel_phasing-.->snp_indel_annotation
 %%{init: {'theme':'dark'}}%%
 flowchart LR
 
-ont_data_f1("Sample 1 \n\n Input data: \n\n ONT fastq.gz")
-ont_data_f2("Sample 1 \n\n Input data: \n\n ONT fastq.gz")
-pacbio_data_f3("Sample 2 \n\n Input data: \n\n Pacbio HiFi uBAM")
-pacbio_data_f4("Sample 2 \n\n Input data: \n\n Pacbio HiFi uBAM")
-ont_data_f5("Sample 3 \n\n Input data: \n\n ONT fastq")
-ont_data_f6("Sample 4 \n\n Input data: \n\n ONT uBAM")
+ont_data_f1("Sample 1 <br><br> Input data: <br><br> ONT fastq.gz")
+ont_data_f2("Sample 1 <br><br> Input data: <br><br> ONT fastq.gz")
+pacbio_data_f3("Sample 2 <br><br> Input data: <br><br> Pacbio HiFi uBAM")
+pacbio_data_f4("Sample 2 <br><br> Input data: <br><br> Pacbio HiFi uBAM")
+ont_data_f5("Sample 3 <br><br> Input data: <br><br> ONT fastq")
+ont_data_f6("Sample 4 <br><br> Input data: <br><br> ONT uBAM")
 
-merging_m1{{"Description: merge runs \n\n Main tools: GNU coreutils \n\n Commands: cat"}}
-merging_m2{{"Description: merge runs \n\n Main tools: Samtools \n\n Commands: samtools merge"}}
+merging_m1{{"Description: merge runs <br><br> Main tools: GNU coreutils <br><br> Commands: cat"}}
+merging_m2{{"Description: merge runs <br><br> Main tools: Samtools <br><br> Commands: samtools merge"}}
 
-alignment_s1{{"Description: alignment, sorting \n\n Main tools: Minimap2 and Samtools \n\n Commands: minimap2 and samtools sort"}}
-alignment_s2{{"Description: alignment, sorting \n\n Main tools: Minimap2 and Samtools \n\n Commands: minimap2 and samtools sort"}}
-alignment_s3{{"Description: bam to fastq conversion, alignment, sorting \n\n Main tools: Minimap2 and Samtools \n\n Commands: minimap2 and samtools sort"}}
-alignment_s4{{"Description: bam to fastq conversion, alignment, sorting \n\n Main tools: Minimap2 and Samtools \n\n Commands: minimap2 and samtools sort"}}
+alignment_s1{{"Description: alignment, sorting <br><br> Main tools: Minimap2 and Samtools <br><br> Commands: minimap2 and samtools sort"}}
+alignment_s2{{"Description: alignment, sorting <br><br> Main tools: Minimap2 and Samtools <br><br> Commands: minimap2 and samtools sort"}}
+alignment_s3{{"Description: bam to fastq conversion, alignment, sorting <br><br> Main tools: Minimap2 and Samtools <br><br> Commands: minimap2 and samtools sort"}}
+alignment_s4{{"Description: bam to fastq conversion, alignment, sorting <br><br> Main tools: Minimap2 and Samtools <br><br> Commands: minimap2 and samtools sort"}}
 
-depth_s1{{"Description: calculate alignment depth \n\n Main tools: Samtools \n\n Commands: samtools depth"}}
-depth_s2{{"Description: calculate alignment depth \n\n Main tools: Samtools \n\n Commands: samtools depth"}}
-depth_s3{{"Description: calculate alignment depth \n\n Main tools: Samtools \n\n Commands: samtools depth"}}
-depth_s4{{"Description: calculate alignment depth \n\n Main tools: Samtools \n\n Commands: samtools depth"}}
+depth_s1{{"Description: calculate alignment depth <br><br> Main tools: Samtools <br><br> Commands: samtools depth"}}
+depth_s2{{"Description: calculate alignment depth <br><br> Main tools: Samtools <br><br> Commands: samtools depth"}}
+depth_s3{{"Description: calculate alignment depth <br><br> Main tools: Samtools <br><br> Commands: samtools depth"}}
+depth_s4{{"Description: calculate alignment depth <br><br> Main tools: Samtools <br><br> Commands: samtools depth"}}
 
-snp_indel_calling_s1{{"Description: SNP/indel variant calling \n\n Main tools: Clair3 or DeepVariant \n\n Commands: run_clair3.sh or run_deepvariant"}}
-snp_indel_calling_s2{{"Description: SNP/indel variant calling \n\n Main tools: Clair3 or DeepVariant \n\n Commands: run_clair3.sh or run_deepvariant"}}
-snp_indel_calling_s3{{"Description: SNP/indel variant calling \n\n Main tools: Clair3 or DeepVariant \n\n Commands: run_clair3.sh or run_deepvariant"}}
-snp_indel_calling_s4{{"Description: SNP/indel variant calling \n\n Main tools: Clair3 or DeepVariant \n\n Commands: run_clair3.sh or run_deepvariant"}}
+snp_indel_calling_s1{{"Description: SNP/indel variant calling <br><br> Main tools: Clair3 or DeepVariant <br><br> Commands: run_clair3.sh or run_deepvariant"}}
+snp_indel_calling_s2{{"Description: SNP/indel variant calling <br><br> Main tools: Clair3 or DeepVariant <br><br> Commands: run_clair3.sh or run_deepvariant"}}
+snp_indel_calling_s3{{"Description: SNP/indel variant calling <br><br> Main tools: Clair3 or DeepVariant <br><br> Commands: run_clair3.sh or run_deepvariant"}}
+snp_indel_calling_s4{{"Description: SNP/indel variant calling <br><br> Main tools: Clair3 or DeepVariant <br><br> Commands: run_clair3.sh or run_deepvariant"}}
 
-snp_indel_phasing_s1{{"Description: SNP/indel phasing \n\n Main tools: WhatsHap \n\n Commands: whatshap phase"}}
-snp_indel_phasing_s2{{"Description: SNP/indel phasing \n\n Main tools: WhatsHap \n\n Commands: whatshap phase"}}
-snp_indel_phasing_s3{{"Description: SNP/indel phasing \n\n Main tools: WhatsHap \n\n Commands: whatshap phase"}}
-snp_indel_phasing_s4{{"Description: SNP/indel phasing \n\n Main tools: WhatsHap \n\n Commands: whatshap phase"}}
+snp_indel_phasing_s1{{"Description: SNP/indel phasing <br><br> Main tools: WhatsHap <br><br> Commands: whatshap phase"}}
+snp_indel_phasing_s2{{"Description: SNP/indel phasing <br><br> Main tools: WhatsHap <br><br> Commands: whatshap phase"}}
+snp_indel_phasing_s3{{"Description: SNP/indel phasing <br><br> Main tools: WhatsHap <br><br> Commands: whatshap phase"}}
+snp_indel_phasing_s4{{"Description: SNP/indel phasing <br><br> Main tools: WhatsHap <br><br> Commands: whatshap phase"}}
 
-snp_indel_annotation_s1{{"SNP/indel annotation (optional - hg38 only)"}}
-snp_indel_annotation_s2{{"SNP/indel annotation (optional - hg38 only)"}}
-snp_indel_annotation_s3{{"SNP/indel annotation (optional - hg38 only)"}}
-snp_indel_annotation_s4{{"SNP/indel annotation (optional - hg38 only)"}}
+snp_indel_annotation_s1{{"Description: SNP/indel annotation (optional - hg38 only)" <br><br> Main tools: ensembl-vep <br><br> Commands: vep}}
+snp_indel_annotation_s2{{"Description: SNP/indel annotation (optional - hg38 only)" <br><br> Main tools: ensembl-vep <br><br> Commands: vep}}
+snp_indel_annotation_s3{{"Description: SNP/indel annotation (optional - hg38 only)" <br><br> Main tools: ensembl-vep <br><br> Commands: vep}}
+snp_indel_annotation_s4{{"Description: SNP/indel annotation (optional - hg38 only)" <br><br> Main tools: ensembl-vep <br><br> Commands: vep}}
 
-haplotagging_s1{{"Description: haplotagging bams \n\n Main tools: WhatsHap \n\n Commands: whatshap haplotag"}}
-haplotagging_s2{{"Description: haplotagging bams \n\n Main tools: WhatsHap \n\n Commands: whatshap haplotag"}}
-haplotagging_s3{{"Description: haplotagging bams \n\n Main tools: WhatsHap \n\n Commands: whatshap haplotag"}}
-haplotagging_s4{{"Description: haplotagging bams \n\n Main tools: WhatsHap \n\n Commands: whatshap haplotag"}}
+haplotagging_s1{{"Description: haplotagging bams <br><br> Main tools: WhatsHap <br><br> Commands: whatshap haplotag"}}
+haplotagging_s2{{"Description: haplotagging bams <br><br> Main tools: WhatsHap <br><br> Commands: whatshap haplotag"}}
+haplotagging_s3{{"Description: haplotagging bams <br><br> Main tools: WhatsHap <br><br> Commands: whatshap haplotag"}}
+haplotagging_s4{{"Description: haplotagging bams <br><br> Main tools: WhatsHap <br><br> Commands: whatshap haplotag"}}
 
-sv_calling_s1{{"Description: structural variant calling \n\n Main tools: Sniffles2 and/or cuteSV \n\n Commands: sniffles and/or cuteSV"}}
-sv_calling_s2{{"Description: structural variant calling \n\n Main tools: Sniffles2 and/or cuteSV \n\n Commands: sniffles and/or cuteSV"}}
-sv_calling_s3{{"Description: structural variant calling \n\n Main tools: Sniffles2 and/or cuteSV \n\n Commands: sniffles and/or cuteSV"}}
-sv_calling_s4{{"Description: structural variant calling \n\n Main tools: Sniffles2 and/or cuteSV \n\n Commands: sniffles and/or cuteSV"}}
+sv_calling_s1{{"Description: structural variant calling <br><br> Main tools: Sniffles2 and/or cuteSV <br><br> Commands: sniffles and/or cuteSV"}}
+sv_calling_s2{{"Description: structural variant calling <br><br> Main tools: Sniffles2 and/or cuteSV <br><br> Commands: sniffles and/or cuteSV"}}
+sv_calling_s3{{"Description: structural variant calling <br><br> Main tools: Sniffles2 and/or cuteSV <br><br> Commands: sniffles and/or cuteSV"}}
+sv_calling_s4{{"Description: structural variant calling <br><br> Main tools: Sniffles2 and/or cuteSV <br><br> Commands: sniffles and/or cuteSV"}}
 
 ont_data_f1-.->merging_m1-.->alignment_s1-.->snp_indel_calling_s1-.->snp_indel_phasing_s1-.->haplotagging_s1-.->sv_calling_s1
 ont_data_f2-.->merging_m1

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ alignment_s2{{"Description: alignment, sorting <br><br> Main tools: Minimap2 and
 alignment_s3{{"Description: bam to fastq conversion, alignment, sorting <br><br> Main tools: Minimap2 and Samtools <br><br> Commands: minimap2 and samtools sort"}}
 alignment_s4{{"Description: bam to fastq conversion, alignment, sorting <br><br> Main tools: Minimap2 and Samtools <br><br> Commands: minimap2 and samtools sort"}}
 
-depth_s1{{"Description: calculate alignment depth <br><br> Main tools: Samtools <br><br> Commands: samtools depth"}}
-depth_s2{{"Description: calculate alignment depth <br><br> Main tools: Samtools <br><br> Commands: samtools depth"}}
-depth_s3{{"Description: calculate alignment depth <br><br> Main tools: Samtools <br><br> Commands: samtools depth"}}
-depth_s4{{"Description: calculate alignment depth <br><br> Main tools: Samtools <br><br> Commands: samtools depth"}}
+depth_s1{{"Description: calculate alignment depth <br><br> Main tools: mosdepth <br><br> Commands: mosdepth depth"}}
+depth_s2{{"Description: calculate alignment depth <br><br> Main tools: mosdepth <br><br> Commands: mosdepth depth"}}
+depth_s3{{"Description: calculate alignment depth <br><br> Main tools: mosdepth <br><br> Commands: mosdepth depth"}}
+depth_s4{{"Description: calculate alignment depth <br><br> Main tools: mosdepth <br><br> Commands: mosdepth depth"}}
 
 snp_indel_calling_s1{{"Description: SNP/indel variant calling <br><br> Main tools: Clair3 or DeepVariant <br><br> Commands: run_clair3.sh or run_deepvariant"}}
 snp_indel_calling_s2{{"Description: SNP/indel variant calling <br><br> Main tools: Clair3 or DeepVariant <br><br> Commands: run_clair3.sh or run_deepvariant"}}
@@ -123,6 +123,7 @@ snp_indel_phasing_s4-.->snp_indel_annotation_s4
 - [WhatsHap](https://github.com/whatshap/whatshap)
 - [Sniffles2](https://github.com/fritzsedlazeck/Sniffles) and/or [cuteSV](https://github.com/tjiangHIT/cuteSV)
 - [Samtools](https://github.com/samtools/samtools)
+- [mosdepth](https://github.com/brentp/mosdepth)
 - [ensembl-vep](https://github.com/Ensembl/ensembl-vep)
 
 ## Main input files

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Pipefaceee.
 
-Nextflow pipeline to align, variant call (SNP's, indels's, SV's), phase and annotate (optional) long read [ONT](https://nanoporetech.com/) and/or [pacbio](https://www.pacb.com/) HiFi data.
+Nextflow pipeline to align, variant call (SNP's, indels's, SV's), phase and annotate (optional - hg38 only) long read [ONT](https://nanoporetech.com/) and/or [pacbio](https://www.pacb.com/) HiFi data.
 
 There currently exists tools and workflows which align, variant call, phase and annotate ONT/pacbio HiFi data, but pipeface serves as a central workflow to process long read data. Pipeface's future hold's STR, CNV and tandem repeat calling, as well as the analysis of cohorts.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ alignment{{"bam to fastq conversion (if needed), alignment, sorting"}}
 depth{{"Calculate alignment depth"}}
 snp_indel_calling{{"SNP/indel variant calling"}}
 snp_indel_phasing{{"SNP/indel phasing"}}
-snp_indel_annotation{{"SNP/indel annotation (optional)"}}
+snp_indel_annotation{{"SNP/indel annotation (optional - hg38 only)"}}
 haplotagging{{"Haplotagging bams"}}
 sv_calling{{"Structural variant calling"}}
 
@@ -69,6 +69,11 @@ snp_indel_phasing_s1{{"Description: SNP/indel phasing \n\n Main tools: WhatsHap 
 snp_indel_phasing_s2{{"Description: SNP/indel phasing \n\n Main tools: WhatsHap \n\n Commands: whatshap phase"}}
 snp_indel_phasing_s3{{"Description: SNP/indel phasing \n\n Main tools: WhatsHap \n\n Commands: whatshap phase"}}
 snp_indel_phasing_s4{{"Description: SNP/indel phasing \n\n Main tools: WhatsHap \n\n Commands: whatshap phase"}}
+
+snp_indel_annotation_s1{{"SNP/indel annotation (optional - hg38 only)"}}
+snp_indel_annotation_s2{{"SNP/indel annotation (optional - hg38 only)"}}
+snp_indel_annotation_s3{{"SNP/indel annotation (optional - hg38 only)"}}
+snp_indel_annotation_s4{{"SNP/indel annotation (optional - hg38 only)"}}
 
 haplotagging_s1{{"Description: haplotagging bams \n\n Main tools: WhatsHap \n\n Commands: whatshap haplotag"}}
 haplotagging_s2{{"Description: haplotagging bams \n\n Main tools: WhatsHap \n\n Commands: whatshap haplotag"}}
@@ -137,7 +142,7 @@ snp_indel_phasing_s4-.->snp_indel_annotation_s4
 
 - Aligned, sorted and haplotagged bam
 - Clair3 or DeepVariant phased SNP/indel VCF file
-- Annotated Clair3 or DeepVariant phased SNP/indel VCF file (optional)
+- Annotated Clair3 or DeepVariant phased SNP/indel VCF file (optional - hg38 only)
 - Phased Sniffles2 and/or un-phased cuteSV SV VCF file
 
 ## Assumptions

--- a/config/nextflow_pipeface.config
+++ b/config/nextflow_pipeface.config
@@ -51,7 +51,7 @@ process {
         cpus = '32'
         time = '6h'
         memory = '128GB'
-        module = 'clair3/v1.0.9:htslib/1.16'
+        module = 'clair3/v1.0.9'
     }
 
     withName: deepvariant {

--- a/config/nextflow_pipeface.config
+++ b/config/nextflow_pipeface.config
@@ -48,7 +48,7 @@ process {
         module = 'minimap2/2.28:samtools/1.19'
     }
 
-    withName: depth {
+    withName: mosdepth {
         queue = 'normal'
         cpus = '8'
         time = '4h'
@@ -105,7 +105,7 @@ process {
         module = 'cuteSV/1.0.13:htslib/1.16'
     }
 
-    withName: 'publish_settings|publish_bam_header|publish_depth|publish_whatshap_phase|publish_whatshap_haplotag|publish_sniffles|publish_cutesv' {
+    withName: 'publish_settings|publish_bam_header|publish_mosdepth|publish_whatshap_phase|publish_whatshap_haplotag|publish_sniffles|publish_cutesv' {
         queue = 'normal'
         cpus = '1'
         time = '20m'

--- a/config/nextflow_pipeface.config
+++ b/config/nextflow_pipeface.config
@@ -43,7 +43,7 @@ process {
     withName: minimap2 {
         queue = 'normal'
         cpus = '16'
-        time = '10h'
+        time = '14h'
         memory = '64GB'
         module = 'minimap2/2.28:samtools/1.19'
     }
@@ -59,7 +59,7 @@ process {
     withName: clair3 {
         queue = 'normal'
         cpus = '32'
-        time = '6h'
+        time = '9h'
         memory = '128GB'
         module = 'clair3/v1.0.9'
     }

--- a/config/nextflow_pipeface.config
+++ b/config/nextflow_pipeface.config
@@ -1,11 +1,22 @@
 
+params.vep_db = '/g/data/if89/datalib/vep/112/grch38/'
+params.revel_db = '/g/data/xy86/revel/1.3/grch38/new_tabbed_revel_grch38.tsv.gz'
+params.gnomad_db = '/g/data/xy86/gnomad/genomes/v4.1.0/gnomad.joint.v4.1.sites.chrall.vcf.gz'
+params.clinvar_db = '/g/data/xy86/clinvar/2024-08-25/grch38/clinvar_20240825.vcf.gz'
+params.cadd_snv_db = '/g/data/xy86/cadd/1.7/grch38/whole_genome_SNVs.tsv.gz'
+params.cadd_indel_db = '/g/data/xy86/cadd/1.7/grch38/gnomad.genomes.r4.0.indel.tsv.gz'
+params.cadd_sv_db = '/g/data/xy86/cadd_sv/1.1/grch38/1000G_phase3_SVs.tsv.gz'
+params.spliceai_snv_db = '/g/data/xy86/spliceai/v1.3/grch38/spliceai_scores.raw.snv.hg38.vcf.gz'
+params.spliceai_indel_db = '/g/data/xy86/spliceai/v1.3/grch38/spliceai_scores.raw.indel.hg38.vcf.gz'
+params.alphamissense_db = '/g/data/xy86/alphamissense/grch38/AlphaMissense_hg38.tsv.gz'
+
 process {
 
     executor = 'pbspro'
     project = 'kr68'
-    storage = 'gdata/if89+scratch/kr68+gdata/kr68+gdata/ox63'
+    storage = 'gdata/if89+gdata/xy86+scratch/kr68+gdata/kr68+gdata/ox63'
     // provide proper access to if89 environmental modules
-    beforeScript = 'module use -a /g/data/if89/apps/modulefiles'
+    beforeScript = 'module use -a /g/data/if89/apps/modulefiles && module use -a /g/data/if89/shpcroot/modules'
 
     withName: scrape_settings {
         queue = 'normal'
@@ -63,7 +74,15 @@ process {
         module = 'parabricks/4.2.1:htslib/1.16'
     }
 
-    withName: 'whatshap_phase_clair3|whatshap_phase_dv|whatshap_haplotag' {
+    withName: vep_snv {
+        queue = 'normal'
+        cpus = '32'
+        time = '6h'
+        memory = '128GB'
+        module = 'singularity:htslib/1.16:ensemblorg/ensembl-vep/release_112.0'
+    }
+
+    withName: 'whatshap_phase|whatshap_haplotag' {
         queue = 'normal'
         cpus = '4'
         time = '10h'
@@ -87,7 +106,7 @@ process {
         module = 'cuteSV/1.0.13:htslib/1.16'
     }
 
-    withName: 'publish_settings|publish_bam_header|publish_minimap2|publish_clair3|publish_deepvariant|publish_whatshap_phase_clair3|publish_whatshap_phase_dv|publish_whatshap_haplotag|publish_sniffles|publish_cutesv' {
+    withName: 'publish_settings|publish_bam_header|publish_depth|publish_whatshap_phase|publish_whatshap_haplotag|publish_sniffles|publish_cutesv' {
         queue = 'normal'
         cpus = '1'
         time = '20m'

--- a/config/nextflow_pipeface.config
+++ b/config/nextflow_pipeface.config
@@ -69,9 +69,10 @@ process {
         queue = 'gpuvolta'
         cpus = '24'
         gpus = '2'
-        time = '6h'
-        memory = '180GB'
-        module = 'parabricks/4.2.1:htslib/1.16'
+        time = '8h'
+        memory = '192GB'
+        disk = '80GB'
+        module = 'singularity'
     }
 
     withName: vep_snv {

--- a/config/nextflow_pipeface.config
+++ b/config/nextflow_pipeface.config
@@ -5,7 +5,6 @@ params.gnomad_db = '/g/data/xy86/gnomad/genomes/v4.1.0/gnomad.joint.v4.1.sites.c
 params.clinvar_db = '/g/data/xy86/clinvar/2024-08-25/grch38/clinvar_20240825.vcf.gz'
 params.cadd_snv_db = '/g/data/xy86/cadd/1.7/grch38/whole_genome_SNVs.tsv.gz'
 params.cadd_indel_db = '/g/data/xy86/cadd/1.7/grch38/gnomad.genomes.r4.0.indel.tsv.gz'
-params.cadd_sv_db = '/g/data/xy86/cadd_sv/1.1/grch38/1000G_phase3_SVs.tsv.gz'
 params.spliceai_snv_db = '/g/data/xy86/spliceai/v1.3/grch38/spliceai_scores.raw.snv.hg38.vcf.gz'
 params.spliceai_indel_db = '/g/data/xy86/spliceai/v1.3/grch38/spliceai_scores.raw.indel.hg38.vcf.gz'
 params.alphamissense_db = '/g/data/xy86/alphamissense/grch38/AlphaMissense_hg38.tsv.gz'

--- a/config/nextflow_pipeface.config
+++ b/config/nextflow_pipeface.config
@@ -53,7 +53,6 @@ process {
         cpus = '8'
         time = '4h'
         memory = '32GB'
-        module = 'samtools/1.19'
     }
 
     withName: clair3 {

--- a/config/parameters_pipeface.json
+++ b/config/parameters_pipeface.json
@@ -8,6 +8,7 @@
     "snp_indel_caller": "",
     "sv_caller": "",
     "annotate": "",
+    "calculate_depth": "",
     "outdir": ""
 
 }

--- a/config/parameters_pipeface.json
+++ b/config/parameters_pipeface.json
@@ -10,6 +10,7 @@
     "annotate": "",
     "calculate_depth": "",
     "outdir": "",
-    "deepvariant_container": ""
+    "deepvariant_container": "",
+    "mosdepth_binary": ""
 
 }

--- a/config/parameters_pipeface.json
+++ b/config/parameters_pipeface.json
@@ -7,6 +7,7 @@
     "tandem_repeat": "",
     "snp_indel_caller": "",
     "sv_caller": "",
+    "annotate": "",
     "outdir": ""
 
 }

--- a/docs/database_versions.txt
+++ b/docs/database_versions.txt
@@ -1,7 +1,7 @@
 vep-cache: homo_sapiens/112/GRCh38
 REVEL database: 1.3
-ClinVar database: 2024-08-25
 gnomAD database: 4.1.0
+ClinVar database: 2024-08-25
 CADD SNV database: 1.7/GRCh38
 CADD indel database: 1.7/GRCh38
 SpliceAI SNV database: 1.3

--- a/docs/database_versions.txt
+++ b/docs/database_versions.txt
@@ -1,0 +1,8 @@
+vep-cache: homo_sapiens/112/GRCh38
+REVEL database: 1.3
+ClinVar database: 2024-08-25
+gnomAD database: 4.1.0
+CADD SNV database: 1.7/GRCh38
+CADD indel database: 1.7/GRCh38
+SpliceAI SNV database: 1.3
+SpliceAI indel database: 1.3

--- a/docs/database_versions.txt
+++ b/docs/database_versions.txt
@@ -6,3 +6,4 @@ CADD SNV database: 1.7/GRCh38
 CADD indel database: 1.7/GRCh38
 SpliceAI SNV database: 1.3
 SpliceAI indel database: 1.3
+AlphaMissense database: GRCh38

--- a/docs/run_on_nci.md
+++ b/docs/run_on_nci.md
@@ -270,10 +270,28 @@ Specify the directory in which to write the pipeline outputs (please provide a f
     "outdir": "/g/data/ox63/results"
 ```
 
-Specify the path to DeepVariant GPU container v1.6.1 (singularity image file). Eg:
+Specify the path to the DeepVariant GPU container v1.6.1 (singularity image file) (if running DeepVariant). Eg:
 
 ```json
     "deepvariant_container": "./deepvariant_1.6.1-gpu.sif"
+```
+
+*OR*
+
+```json
+    "deepvariant_container": "NONE"
+```
+
+Specify the path to the mosdepth binary (if running depth calculation). Eg:
+
+```json
+    "mosdepth_binary": "./mosdepth_0.3.9"
+```
+
+*OR*
+
+```json
+    "mosdepth_binary": "NONE"
 ```
 
 ## 6. Get pipeline dependencies

--- a/docs/run_on_nci.md
+++ b/docs/run_on_nci.md
@@ -10,6 +10,7 @@
       - [ONT](#ont)
       - [Pacbio HiFi revio](#pacbio-hifi-revio)
     - [DeepVariant container (if running DeepVariant)](#deepvariant-container-if-running-deepvariant)
+    - [mosdepth binary (if running depth calculation)](#mosdepth-binary-if-running-depth-calculation)
   - [3. Modify in\_data.csv](#3-modify-in_datacsv)
   - [4. Modify nextflow\_pipeface.config](#4-modify-nextflow_pipefaceconfig)
   - [5. Modify parameters\_pipeface.json](#5-modify-parameters_pipefacejson)
@@ -124,6 +125,15 @@ Get a local copy of the DeepVariant GPU container v1.6.1 (singularity image file
 ```bash
 module load singularity
 singularity pull deepvariant_1.6.1-gpu.sif docker://google/deepvariant:deeptrio-1.6.1-gpu
+```
+
+### mosdepth binary (if running depth calculation)
+
+Get a local copy of the mosdepth v0.3.9 binary
+
+```bash
+wget https://github.com/brentp/mosdepth/releases/download/v0.3.9/mosdepth -O mosdepth_0.3.9
+chmod +x mosdepth_0.3.9
 ```
 
 ## 3. Modify in_data.csv

--- a/docs/run_on_nci.md
+++ b/docs/run_on_nci.md
@@ -150,10 +150,11 @@ Modify the NCI project to which to charge the analysis. Eg:
 Modify access to project specific directories. Eg:
 
 ```txt
-    storage = 'gdata/if89+scratch/kr68+gdata/kr68'
+    storage = 'gdata/if89+gdata/xy86+scratch/kr68+gdata/kr68'
 ```
 
 > **_Note:_** Don't remove access to if89 gdata (`gdata/if89`). This is required to access environmental modules used in the pipeline
+> **_Note:_** Similarly, don't remove access to xy86 gdata (`gdata/xy86`) if running variant annotation. This is required to access variant annotation databases used in the pipeline
 
 ## 5. Modify parameters_pipeface.json
 
@@ -219,6 +220,18 @@ Specify the SV caller to use ('sniffles', 'cutesv' or 'both'). Eg:
     "sv_caller": "both",
 ```
 
+Specify whether variant annotation should be carried out ('yes' or 'no'). Eg:
+
+```json
+    "annotate": "no",
+```
+
+*OR*
+
+```json
+    "annotate": "yes",
+```
+
 Specify the directory in which to write the pipeline outputs (please provide a full path). Eg:
 
 ```json
@@ -251,5 +264,5 @@ The resources requested and the queue each process is submitted to may be modifi
 
 Similarly, with some coding skills, the environmental modules used by each process in the pipeline may be modified. This means you're able to substitute in different versions of software used by the pipeline. However, keep in mind that the pipeline doesn't account for differences in parameterisation between software versions.
 
-This also means this pipeline is adaptable to other HPC's if appropriate environmental modules are included in `./config/nextflow_pipeface.config` (or if you get around to creating a nextflow configuration file pointing to appropriate containerised software before I do) and modify the job scheduler specific configuration if needed.
+This also means this pipeline is adaptable to other HPC's if appropriate environmental modules are included in `./config/nextflow_pipeface.config` (or if you get around to creating a nextflow configuration file pointing to appropriate containerised software before I do) and modify the job scheduler specific configuration if needed. If you wish to use the variant annotation component of the pipeline, you'll additionally need to create local copies of the variant annotation databases used by the pipeline.
 

--- a/docs/run_on_nci.md
+++ b/docs/run_on_nci.md
@@ -9,7 +9,7 @@
     - [Clair3 models](#clair3-models)
       - [ONT](#ont)
       - [Pacbio HiFi revio](#pacbio-hifi-revio)
-  - [3. Modify in_data.csv](#3-modify-in_datacsv)
+  - [3. Modify in\_data.csv](#3-modify-in_datacsv)
   - [4. Modify nextflow\_pipeface.config](#4-modify-nextflow_pipefaceconfig)
   - [5. Modify parameters\_pipeface.json](#5-modify-parameters_pipefacejson)
   - [6. Get pipeline dependencies](#6-get-pipeline-dependencies)

--- a/docs/run_on_nci.md
+++ b/docs/run_on_nci.md
@@ -232,6 +232,18 @@ Specify whether variant annotation should be carried out ('yes' or 'no'). Eg:
     "annotate": "yes",
 ```
 
+Specify whether alignment depth should be calculated ('yes' or 'no'). Eg:
+
+```json
+    "calculate_depth": "no",
+```
+
+*OR*
+
+```json
+    "calculate_depth": "yes",
+```
+
 Specify the directory in which to write the pipeline outputs (please provide a full path). Eg:
 
 ```json

--- a/docs/software_versions.txt
+++ b/docs/software_versions.txt
@@ -1,7 +1,7 @@
 Samtools: 1.19
 Minimap2: 2.28-r1209
 Clair3: 1.0.9
-Clara Parabricks: 4.2.1-1.beta4 (equivalent to - DeepVariant 1.5.0)
+DeepVariant 1.6.1
 WhatsHap: 2.3
 Sniffles2: 2.3.3
 cuteSV: 1.0.13

--- a/docs/software_versions.txt
+++ b/docs/software_versions.txt
@@ -1,5 +1,6 @@
 Samtools: 1.19
 Minimap2: 2.28-r1209
+mosdepth: 0.3.9
 Clair3: 1.0.9
 DeepVariant 1.6.1
 WhatsHap: 2.3

--- a/docs/software_versions.txt
+++ b/docs/software_versions.txt
@@ -8,3 +8,4 @@ cuteSV: 1.0.13
 GNU coreutils: 8.30
 HTSlib: 1.16
 GNU Awk: 4.2.1
+ensembl-vep: 112

--- a/docs/software_versions.txt
+++ b/docs/software_versions.txt
@@ -1,0 +1,10 @@
+Samtools: 1.19
+Minimap2: 2.28-r1209
+Clair3: 1.0.9
+Clara Parabricks: 4.2.1-1.beta4 (equivalent to - DeepVariant 1.5.0)
+WhatsHap: 2.3
+Sniffles2: 2.3.3
+cuteSV: 1.0.13
+GNU coreutils: 8.30
+HTSlib: 1.16
+GNU Awk: 4.2.1

--- a/pipeface.nf
+++ b/pipeface.nf
@@ -238,6 +238,7 @@ process minimap2 {
         """
         # run minimap
         minimap2 \
+        -y \
         --secondary=no \
         --MD \
         -a \

--- a/pipeface.nf
+++ b/pipeface.nf
@@ -293,7 +293,9 @@ process mosdepth {
 
 process publish_mosdepth {
 
-    publishDir "$outdir/$sample_id/$outdir2", mode: 'copy', overwrite: true, saveAs: { filename -> "$sample_id.$ref_name.$filename" }
+    def depth_software = "mosdepth"
+
+    publishDir "$outdir/$sample_id/$outdir2", mode: 'copy', overwrite: true, saveAs: { filename -> "$sample_id.$ref_name.$depth_software.$filename" }
 
     input:
         tuple val(sample_id), path(depth)

--- a/pipeface.nf
+++ b/pipeface.nf
@@ -238,7 +238,6 @@ process minimap2 {
         """
         # run minimap
         minimap2 \
-        -y \
         --secondary=no \
         --MD \
         -a \

--- a/pipeface.nf
+++ b/pipeface.nf
@@ -479,7 +479,6 @@ process vep_snv {
         val clinvar_db
         val cadd_snv_db
         val cadd_indel_db
-        val cadd_sv_db
         val spliceai_snv_db
         val spliceai_indel_db
         val alphamissense_db
@@ -954,7 +953,7 @@ workflow {
     (snp_indel_phased_vcf_bam, whatshap_phase_to_publish, snp_indel_phased_vcf) = whatshap_phase(snp_indel_vcf_bam, ref, ref_index)
     publish_whatshap_phase(whatshap_phase_to_publish, outdir, outdir2, ref_name, snp_indel_caller)
     if ( annotate == 'yes' ) {
-        vep_snv_to_publish = vep_snv(snp_indel_phased_vcf, ref, ref_index, vep_db, revel_db, gnomad_db, clinvar_db, cadd_snv_db, cadd_indel_db, cadd_sv_db, spliceai_snv_db, spliceai_indel_db, alphamissense_db)
+        vep_snv_to_publish = vep_snv(snp_indel_phased_vcf, ref, ref_index, vep_db, revel_db, gnomad_db, clinvar_db, cadd_snv_db, cadd_indel_db, spliceai_snv_db, spliceai_indel_db, alphamissense_db)
         publish_vep_snv(vep_snv_to_publish, outdir, outdir2, ref_name, snp_indel_caller)
     }
     (haplotagged_bam, whatshap_haplotag_to_publish) = whatshap_haplotag(snp_indel_phased_vcf_bam, ref, ref_index)

--- a/pipeface.nf
+++ b/pipeface.nf
@@ -201,7 +201,7 @@ process minimap2 {
 
     output:
         tuple val(sample_id), val(data_type), val(regions_of_interest), val(clair3_model), path('minimap2.sorted.bam'), path('minimap2.sorted.bam.bai')
-        tuple val(sample_id), path('minimap2.sorted.bam'), path('minimap2.version.txt')
+        tuple val(sample_id), path('minimap2.sorted.bam')
 
     script:
     // conditionally define preset
@@ -230,8 +230,6 @@ process minimap2 {
         samtools index \
         -@ ${task.cpus} \
         minimap2.sorted.bam
-        # grab version
-        minimap2 --version > minimap2.version.txt
         """
     else if( extension == 'gz' | extension == 'fastq' )
         """
@@ -249,15 +247,12 @@ process minimap2 {
         samtools index \
         -@ ${task.cpus} \
         minimap2.sorted.bam
-        # grab version
-        minimap2 --version > minimap2.version.txt
         """
 
     stub:
         """
         touch minimap2.sorted.bam
         touch minimap2.sorted.bam.bai
-        touch minimap2.version.txt
         """
 
 }
@@ -265,10 +260,10 @@ process minimap2 {
 process depth {
 
     input:
-        tuple val(sample_id), path(bam), path(minimap2_version)
+        tuple val(sample_id), path(bam)
 
     output:
-        tuple val(sample_id), path('minimap2.version.txt'), path('depth.tsv')
+        tuple val(sample_id), path('depth.tsv')
 
     script:
         """
@@ -297,13 +292,12 @@ process publish_minimap2 {
     publishDir "$outdir/$sample_id/$outdir2", mode: 'copy', overwrite: true, saveAs: { filename -> "$sample_id.$ref_name.$filename" }
 
     input:
-        tuple val(sample_id), path(minimap_version), path(depth)
+        tuple val(sample_id), path(depth)
         val outdir
         val outdir2
         val ref_name
 
     output:
-        path 'minimap2.version.txt'
         path 'depth.tsv'
 
     script:
@@ -313,7 +307,6 @@ process publish_minimap2 {
 
     stub:
         """
-        touch minimap2.version.txt
         touch depth.tsv
         """
 
@@ -328,7 +321,7 @@ process clair3 {
 
     output:
         tuple val(sample_id), val(data_type), path(bam), path(bam_index), path('clair3.snp_indel.vcf.gz'), path('clair3.snp_indel.vcf.gz.tbi')
-        tuple val(sample_id), path('clair3.snp_indel.g.vcf.gz'), path('clair3.snp_indel.g.vcf.gz.tbi'), path('clair3.version.txt')
+        tuple val(sample_id), path('clair3.snp_indel.g.vcf.gz'), path('clair3.snp_indel.g.vcf.gz.tbi')
 
     script:
     // define a string to optionally pass regions of interest bed file
@@ -358,8 +351,6 @@ process clair3 {
         ln -s merge_output.vcf.gz.tbi clair3.snp_indel.vcf.gz.tbi
         ln -s merge_output.gvcf.gz clair3.snp_indel.g.vcf.gz
         ln -s merge_output.gvcf.gz.tbi clair3.snp_indel.g.vcf.gz.tbi
-        # grab version
-        run_clair3.sh --version > clair3.version.txt
         """
 
     stub:
@@ -368,7 +359,6 @@ process clair3 {
         touch clair3.snp_indel.vcf.gz.tbi
         touch clair3.snp_indel.g.vcf.gz
         touch clair3.snp_indel.g.vcf.gz.tbi
-        touch clair3.version.txt
         """
 
 }
@@ -378,7 +368,7 @@ process publish_clair3 {
     publishDir "$outdir/$sample_id/$outdir2", mode: 'copy', overwrite: true, saveAs: { filename -> "$sample_id.$ref_name.$filename" }
 
     input:
-        tuple val(sample_id), path(snp_indel_gvcf), path(snp_indel_gvcf_index), path(version)
+        tuple val(sample_id), path(snp_indel_gvcf), path(snp_indel_gvcf_index)
         val outdir
         val outdir2
         val ref_name
@@ -387,7 +377,6 @@ process publish_clair3 {
         val sample_id
         path 'clair3.snp_indel.g.vcf.gz'
         path 'clair3.snp_indel.g.vcf.gz.tbi'
-        path 'clair3.version.txt'
 
     script:
         """
@@ -398,7 +387,6 @@ process publish_clair3 {
         """
         touch clair3.snp_indel.g.vcf.gz
         touch clair3.snp_indel.g.vcf.gz.tbi
-        touch clair3.version.txt
         """
 
 }
@@ -475,7 +463,7 @@ process deepvariant {
 
     output:
         tuple val(sample_id), val(data_type), path(bam), path(bam_index), path('deepvariant.snp_indel.vcf.gz'), path('deepvariant.snp_indel.vcf.gz.tbi')
-        tuple val(sample_id), path('deepvariant.snp_indel.g.vcf.gz'), path('deepvariant.snp_indel.g.vcf.gz.tbi'), path('deepvariant.version.txt')
+        tuple val(sample_id), path('deepvariant.snp_indel.g.vcf.gz'), path('deepvariant.snp_indel.g.vcf.gz.tbi')
 
     script:
     // define an optional string to pass regions of interest bed file
@@ -497,8 +485,6 @@ process deepvariant {
         -@ ${task.cpus} \
         deepvariant.snp_indel.vcf
         tabix deepvariant.snp_indel.vcf.gz
-        # grab version
-        pbrun deepvariant --version >> deepvariant.version.txt
         """
 
     stub:
@@ -507,7 +493,6 @@ process deepvariant {
         touch deepvariant.snp_indel.vcf.gz.tbi
         touch deepvariant.snp_indel.g.vcf.gz
         touch deepvariant.snp_indel.g.vcf.gz.tbi
-        touch deepvariant.version.txt
         """
 
 }
@@ -517,7 +502,7 @@ process publish_deepvariant {
     publishDir "$outdir/$sample_id/$outdir2", mode: 'copy', overwrite: true, saveAs: { filename -> "$sample_id.$ref_name.$filename" }
 
     input:
-        tuple val(sample_id), path(snp_indel_gvcf), path(snp_indel_gvcf_index), path(deepvariant_version)
+        tuple val(sample_id), path(snp_indel_gvcf), path(snp_indel_gvcf_index)
         val outdir
         val outdir2
         val ref_name
@@ -526,7 +511,6 @@ process publish_deepvariant {
         val sample_id
         path 'deepvariant.snp_indel.g.vcf.gz'
         path 'deepvariant.snp_indel.g.vcf.gz.tbi'
-        path 'deepvariant.version.txt'
 
     script:
         """
@@ -537,7 +521,6 @@ process publish_deepvariant {
         """
         touch deepvariant.snp_indel.g.vcf.gz
         touch deepvariant.snp_indel.g.vcf.gz.tbi
-        touch deepvariant.version.txt
         """
 
 }
@@ -614,7 +597,7 @@ process whatshap_haplotag {
 
     output:
         tuple val(sample_id), val(data_type), path('minimap2.whatshap.sorted.haplotagged.bam'), path('minimap2.whatshap.sorted.haplotagged.bam.bai')
-        tuple val(sample_id), path('minimap2.whatshap.sorted.haplotagged.bam'), path('minimap2.whatshap.sorted.haplotagged.bam.bai'), path('minimap2.whatshap.sorted.haplotagged.tsv'), path('whatshap.version.txt')
+        tuple val(sample_id), path('minimap2.whatshap.sorted.haplotagged.bam'), path('minimap2.whatshap.sorted.haplotagged.bam.bai'), path('minimap2.whatshap.sorted.haplotagged.tsv')
 
     script:
         """
@@ -632,8 +615,6 @@ process whatshap_haplotag {
         samtools index \
         -@ ${task.cpus} \
         minimap2.whatshap.sorted.haplotagged.bam
-        # grab version
-        whatshap --version > whatshap.version.txt
         """
 
     stub:
@@ -641,7 +622,6 @@ process whatshap_haplotag {
         touch minimap2.whatshap.sorted.haplotagged.bam
         touch minimap2.whatshap.sorted.haplotagged.bam.bai
         touch minimap2.whatshap.sorted.haplotagged.tsv
-        touch whatshap.version.txt
         """
 
 }
@@ -651,7 +631,7 @@ process publish_whatshap_haplotag {
     publishDir "$outdir/$sample_id/$outdir2", mode: 'copy', overwrite: true, saveAs: { filename -> "$sample_id.$ref_name.$filename" }
 
     input:
-        tuple val(sample_id), path(haplotagged_bam), path(haplotagged_bam_index), path(haplotagged_bam_tsv), path(whatshap_version)
+        tuple val(sample_id), path(haplotagged_bam), path(haplotagged_bam_index), path(haplotagged_bam_tsv)
         val outdir
         val outdir2
         val ref_name
@@ -660,7 +640,6 @@ process publish_whatshap_haplotag {
         path 'minimap2.whatshap.sorted.haplotagged.bam'
         path 'minimap2.whatshap.sorted.haplotagged.bam.bai'
         path 'minimap2.whatshap.sorted.haplotagged.tsv'
-        path 'whatshap.version.txt'
 
     script:
         """
@@ -672,7 +651,6 @@ process publish_whatshap_haplotag {
         touch minimap2.whatshap.sorted.haplotagged.bam
         touch minimap2.whatshap.sorted.haplotagged.bam.bai
         touch minimap2.whatshap.sorted.haplotagged.tsv
-        touch whatshap.version.txt
         """
 
 }
@@ -686,7 +664,7 @@ process sniffles {
         val tandem_repeat
 
     output:
-        tuple val(sample_id), path('sniffles.sv.phased.vcf.gz'), path('sniffles.sv.phased.vcf.gz.tbi'), path('sniffles.sv.phased.snf'), path('sniffles.version.txt')
+        tuple val(sample_id), path('sniffles.sv.phased.vcf.gz'), path('sniffles.sv.phased.vcf.gz.tbi'), path('sniffles.sv.phased.snf')
 
     script:
     // define a string to optionally pass tandem repeat bed file
@@ -703,8 +681,6 @@ process sniffles {
         --output-rnames \
         --minsvlen 20 \
         --phase $tandem_repeat_optional
-        # grab version
-        sniffles --version > sniffles.version.txt
         """
 
     stub:
@@ -712,7 +688,6 @@ process sniffles {
         touch sniffles.sv.phased.vcf.gz
         touch sniffles.sv.phased.vcf.gz.tbi
         touch sniffles.sv.phased.snf
-        touch sniffles.version.txt
         """
 
 }
@@ -722,7 +697,7 @@ process publish_sniffles {
     publishDir "$outdir/$sample_id/$outdir2", mode: 'copy', overwrite: true, saveAs: { filename -> "$sample_id.$ref_name.$filename" }
 
     input:
-        tuple val(sample_id), path(sv_vcf), path(sv_vcf_index), path(sv_snf), path(sniffles_version)
+        tuple val(sample_id), path(sv_vcf), path(sv_vcf_index), path(sv_snf)
         val outdir
         val outdir2
         val ref_name
@@ -731,7 +706,6 @@ process publish_sniffles {
         path 'sniffles.sv.phased.vcf.gz'
         path 'sniffles.sv.phased.vcf.gz.tbi'
         path 'sniffles.sv.phased.snf'
-        path 'sniffles.version.txt'
 
     script:
         """
@@ -743,7 +717,6 @@ process publish_sniffles {
         touch sniffles.sv.phased.vcf.gz
         touch sniffles.sv.phased.vcf.gz.tbi
         touch sniffles.sv.phased.snf
-        touch sniffles.version.txt
         """
 
 }
@@ -757,7 +730,7 @@ process cutesv {
         val tandem_repeat
 
     output:
-        tuple val(sample_id), path('cutesv.sv.vcf.gz'), path('cutesv.sv.vcf.gz.tbi'), path('cutesv.version.txt')
+        tuple val(sample_id), path('cutesv.sv.vcf.gz'), path('cutesv.sv.vcf.gz.tbi')
 
     script:
     if( data_type == 'ont' ) {
@@ -783,15 +756,12 @@ process cutesv {
         -@ ${task.cpus} \
         cutesv.sv.vcf
         tabix cutesv.sv.vcf.gz
-        # grab version
-        cuteSV --version > cutesv.version.txt
         """
 
     stub:
         """
         touch cutesv.sv.vcf.gz
         touch cutesv.sv.vcf.gz.tbi
-        touch cutesv.version.txt
         """
 
 }
@@ -801,7 +771,7 @@ process publish_cutesv {
     publishDir "$outdir/$sample_id/$outdir2", mode: 'copy', overwrite: true, saveAs: { filename -> "$sample_id.$ref_name.$filename" }
 
     input:
-        tuple val(sample_id), path(sv_vcf), path(sv_vcf_index), path(cutesv_version)
+        tuple val(sample_id), path(sv_vcf), path(sv_vcf_index)
         val outdir
         val outdir2
         val ref_name
@@ -809,7 +779,6 @@ process publish_cutesv {
     output:
         path 'cutesv.sv.vcf.gz'
         path 'cutesv.sv.vcf.gz.tbi'
-        path 'cutesv.version.txt'
 
     script:
         """
@@ -820,7 +789,6 @@ process publish_cutesv {
         """
         touch cutesv.sv.vcf.gz
         touch cutesv.sv.vcf.gz.tbi
-        touch cutesv.version.txt
         """
 
 }

--- a/pipeface.nf
+++ b/pipeface.nf
@@ -18,6 +18,7 @@ process scrape_settings {
         val snp_indel_caller
         val sv_caller
         val annotate
+        val calculate_depth
         val outdir
 
     output:
@@ -47,6 +48,7 @@ process scrape_settings {
         echo "SNP/indel caller: $snp_indel_caller" >> pipeface_settings.txt
         echo "SV caller: $reported_sv_caller" >> pipeface_settings.txt
         echo "Annotate: $annotate" >> pipeface_settings.txt
+        echo "Calculate depth: $calculate_depth" >> pipeface_settings.txt
         echo "Outdir: $outdir" >> pipeface_settings.txt
         """
 
@@ -941,7 +943,7 @@ workflow {
     }
 
     // workflow
-    scrape_settings_to_publish = scrape_settings(in_data_tuple, in_data, ref, ref_index, tandem_repeat, snp_indel_caller, sv_caller, annotate, outdir)
+    scrape_settings_to_publish = scrape_settings(in_data_tuple, in_data, ref, ref_index, tandem_repeat, snp_indel_caller, sv_caller, annotate, calculate_depth, outdir)
     publish_settings(scrape_settings_to_publish, outdir, outdir2, ref_name)
     bam_header = scrape_bam_header(in_data_list)
     publish_bam_header(bam_header, outdir, outdir2)

--- a/pipeface.nf
+++ b/pipeface.nf
@@ -261,7 +261,7 @@ process minimap2 {
 
 }
 
-process depth {
+process mosdepth {
 
     input:
         tuple val(sample_id), val(regions_of_interest), path(bam), path(bam_index)
@@ -290,7 +290,7 @@ process depth {
 
 }
 
-process publish_depth {
+process publish_mosdepth {
 
     publishDir "$outdir/$sample_id/$outdir2", mode: 'copy', overwrite: true, saveAs: { filename -> "$sample_id.$ref_name.$filename" }
 
@@ -964,8 +964,8 @@ workflow {
     merged = merge_runs(in_data_tuple)
     (bam, minimap_to_publish1) = minimap2(merged, ref, ref_index)
     if ( calculate_depth == 'yes' ) {
-        minimap_to_publish2 = depth(minimap_to_publish1)
-        publish_depth(minimap_to_publish2, outdir, outdir2, ref_name)
+        minimap_to_publish2 = mosdepth(minimap_to_publish1)
+        publish_mosdepth(minimap_to_publish2, outdir, outdir2, ref_name)
     }
     if ( snp_indel_caller == 'clair3' ) {
         (snp_indel_vcf_bam, snp_indel_vcf) = clair3(bam, ref, ref_index)

--- a/pipeface.nf
+++ b/pipeface.nf
@@ -847,6 +847,9 @@ workflow {
     if ( annotate == 'yes' && !file(spliceai_indel_db).exists() ) {
         exit 1, "Error SpliceAI indel database file path does not exist, '${spliceai_indel_db}' provided."
     }
+    if ( annotate == 'yes' && !file(alphamissense_db).exists() ) {
+        exit 1, "Error AlphaMissense database file path does not exist, '${alphamissense_db}' provided."
+    }
     if ( !outdir ) {
         exit 1, "Error: No output directory provided. Either include in parameter file or pass to --outdir on the command line."
     }

--- a/pipeface.nf
+++ b/pipeface.nf
@@ -1,9 +1,11 @@
+
 nextflow.enable.dsl=2
 
 // set defaults for optional params (set default optional input files to dummy NONE file)
 // secret sauce second outdir
 params.outdir2 = ""
 params.tandem_repeat = "NONE"
+params.annotate_override = ""
 
 process scrape_settings {
 
@@ -15,6 +17,7 @@ process scrape_settings {
         val tandem_repeat
         val snp_indel_caller
         val sv_caller
+        val annotate
         val outdir
 
     output:
@@ -43,6 +46,7 @@ process scrape_settings {
         echo "Tandem repeat file: $tandem_repeat" >> pipeface_settings.txt
         echo "SNP/indel caller: $snp_indel_caller" >> pipeface_settings.txt
         echo "SV caller: $reported_sv_caller" >> pipeface_settings.txt
+        echo "Annotate: $annotate" >> pipeface_settings.txt
         echo "Outdir: $outdir" >> pipeface_settings.txt
         """
 
@@ -177,7 +181,7 @@ process merge_runs {
     else if( extension == 'bam' )
         """
         ${
-            if (files instanceof List && files.size() > 1) { 
+            if (files instanceof List && files.size() > 1) {
                 "samtools merge -@ ${task.cpus} ${files} -o merged"
             } else {
                 "ln -s ${files} merged"
@@ -200,8 +204,8 @@ process minimap2 {
         val ref_index
 
     output:
-        tuple val(sample_id), val(data_type), val(regions_of_interest), val(clair3_model), path('minimap2.sorted.bam'), path('minimap2.sorted.bam.bai')
-        tuple val(sample_id), path('minimap2.sorted.bam')
+        tuple val(sample_id), val(data_type), val(regions_of_interest), val(clair3_model), path('sorted.bam'), path('sorted.bam.bai')
+        tuple val(sample_id), path('sorted.bam')
 
     script:
     // conditionally define preset
@@ -225,11 +229,11 @@ process minimap2 {
         -x $preset \
         -t ${task.cpus} \
         -R '@RG\\t$sample_id:S1\\tSM:$sample_id' \
-        $ref - | samtools sort -@ ${task.cpus} -o minimap2.sorted.bam -
+        $ref - | samtools sort -@ ${task.cpus} -o sorted.bam -
         # index bam
         samtools index \
         -@ ${task.cpus} \
-        minimap2.sorted.bam
+        sorted.bam
         """
     else if( extension == 'gz' | extension == 'fastq' )
         """
@@ -242,17 +246,17 @@ process minimap2 {
         -t ${task.cpus} \
         $ref \
         -R '@RG\\tID:$sample_id\\tSM:$sample_id' \
-        $merged | samtools sort -@ ${task.cpus} -o minimap2.sorted.bam -
+        $merged | samtools sort -@ ${task.cpus} -o sorted.bam -
         # index bam
         samtools index \
         -@ ${task.cpus} \
-        minimap2.sorted.bam
+        sorted.bam
         """
 
     stub:
         """
-        touch minimap2.sorted.bam
-        touch minimap2.sorted.bam.bai
+        touch sorted.bam
+        touch sorted.bam.bai
         """
 
 }
@@ -287,7 +291,7 @@ process depth {
 
 }
 
-process publish_minimap2 {
+process publish_depth {
 
     publishDir "$outdir/$sample_id/$outdir2", mode: 'copy', overwrite: true, saveAs: { filename -> "$sample_id.$ref_name.$filename" }
 
@@ -320,8 +324,7 @@ process clair3 {
         val ref_index
 
     output:
-        tuple val(sample_id), val(data_type), path(bam), path(bam_index), path('clair3.snp_indel.vcf.gz'), path('clair3.snp_indel.vcf.gz.tbi')
-        tuple val(sample_id), path('clair3.snp_indel.g.vcf.gz'), path('clair3.snp_indel.g.vcf.gz.tbi')
+        tuple val(sample_id), val(data_type), path(bam), path(bam_index), path('snp_indel.vcf.gz'), path('snp_indel.vcf.gz.tbi')
 
     script:
     // define a string to optionally pass regions of interest bed file
@@ -347,109 +350,14 @@ process clair3 {
         --include_all_ctgs \
         $regions_of_interest_optional
         # rename files
-        ln -s merge_output.vcf.gz clair3.snp_indel.vcf.gz
-        ln -s merge_output.vcf.gz.tbi clair3.snp_indel.vcf.gz.tbi
-        ln -s merge_output.gvcf.gz clair3.snp_indel.g.vcf.gz
-        ln -s merge_output.gvcf.gz.tbi clair3.snp_indel.g.vcf.gz.tbi
+        ln -s merge_output.vcf.gz snp_indel.vcf.gz
+        ln -s merge_output.vcf.gz.tbi snp_indel.vcf.gz.tbi
         """
 
     stub:
         """
-        touch clair3.snp_indel.vcf.gz
-        touch clair3.snp_indel.vcf.gz.tbi
-        touch clair3.snp_indel.g.vcf.gz
-        touch clair3.snp_indel.g.vcf.gz.tbi
-        """
-
-}
-
-process publish_clair3 {
-
-    publishDir "$outdir/$sample_id/$outdir2", mode: 'copy', overwrite: true, saveAs: { filename -> "$sample_id.$ref_name.$filename" }
-
-    input:
-        tuple val(sample_id), path(snp_indel_gvcf), path(snp_indel_gvcf_index)
-        val outdir
-        val outdir2
-        val ref_name
-
-    output:
-        val sample_id
-        path 'clair3.snp_indel.g.vcf.gz'
-        path 'clair3.snp_indel.g.vcf.gz.tbi'
-
-    script:
-        """
-        echo "Publishing files"
-        """
-
-    stub:
-        """
-        touch clair3.snp_indel.g.vcf.gz
-        touch clair3.snp_indel.g.vcf.gz.tbi
-        """
-
-}
-
-process whatshap_phase_clair3 {
-
-    input:
-        tuple val(sample_id), val(data_type), path(bam), path(bam_index), path(snp_indel_vcf), path(snp_indel_vcf_index)
-        val ref
-        val ref_index
-
-    output:
-        tuple val(sample_id), val(data_type), path(bam), path(bam_index), path('clair3.snp_indel.phased.vcf.gz'), path('clair3.snp_indel.phased.vcf.gz.tbi')
-        tuple val(sample_id), path('clair3.snp_indel.phased.vcf.gz'), path('clair3.snp_indel.phased.vcf.gz.tbi'), path('clair3.snp_indel.phased.read_list.txt')
-
-    script:
-        """
-        # run whatshap phase
-        whatshap phase \
-        --reference $ref \
-        --output clair3.snp_indel.phased.vcf.gz \
-        --output-read-list clair3.snp_indel.phased.read_list.txt \
-        --sample $sample_id \
-        --ignore-read-groups $snp_indel_vcf $bam
-        # index vcf
-        tabix clair3.snp_indel.phased.vcf.gz
-        """
-
-    stub:
-        """
-        touch clair3.snp_indel.phased.vcf.gz
-        touch clair3.snp_indel.phased.vcf.gz.tbi
-        touch clair3.snp_indel.phased.read_list.txt
-        """
-
-}
-
-process publish_whatshap_phase_clair3 {
-
-    publishDir "$outdir/$sample_id/$outdir2", mode: 'copy', overwrite: true, saveAs: { filename -> "$sample_id.$ref_name.$filename" }
-
-    input:
-        tuple val(sample_id), path(snp_indel_phased_vcf), path(snp_indel_phased_vcf_index), path(snp_indel_phased_read_list)
-        val outdir
-        val outdir2
-        val ref_name
-
-    output:
-        val sample_id
-        path 'clair3.snp_indel.phased.vcf.gz'
-        path 'clair3.snp_indel.phased.vcf.gz.tbi'
-        path 'clair3.snp_indel.phased.read_list.txt'
-
-    script:
-        """
-        echo "Publishing files"
-        """
-
-    stub:
-        """
-        touch clair3.snp_indel.phased.vcf.gz
-        touch clair3.snp_indel.phased.vcf.gz.tbi
-        touch clair3.snp_indel.phased.read_list.txt
+        touch snp_indel.vcf.gz
+        touch snp_indel.vcf.gz.tbi
         """
 
 }
@@ -462,11 +370,10 @@ process deepvariant {
         val ref_index
 
     output:
-        tuple val(sample_id), val(data_type), path(bam), path(bam_index), path('deepvariant.snp_indel.vcf.gz'), path('deepvariant.snp_indel.vcf.gz.tbi')
-        tuple val(sample_id), path('deepvariant.snp_indel.g.vcf.gz'), path('deepvariant.snp_indel.g.vcf.gz.tbi')
+        tuple val(sample_id), val(data_type), path(bam), path(bam_index), path('snp_indel.vcf.gz'), path('snp_indel.vcf.gz.tbi')
 
     script:
-    // define an optional string to pass regions of interest bed file
+    // define a string to optionally pass regions of interest bed file
     def regions_of_interest_optional = file(regions_of_interest).name != 'NONE' ? "-L $regions_of_interest" : ''
         """
         # run deepvariant
@@ -474,8 +381,7 @@ process deepvariant {
         --mode $data_type \
         --ref $ref \
         --in-bam $bam \
-        --gvcf \
-        --out-variants deepvariant.snp_indel.g.vcf.gz \
+        --out-variants snp_indel.vcf \
         --num-gpus ${task.gpus} \
         --num-cpu-threads-per-stream ${task.cpus} \
         --num-streams-per-gpu 1 \
@@ -483,49 +389,19 @@ process deepvariant {
         # compress and index vcf
         bgzip \
         -@ ${task.cpus} \
-        deepvariant.snp_indel.vcf
-        tabix deepvariant.snp_indel.vcf.gz
+        snp_indel.vcf
+        tabix snp_indel.vcf.gz
         """
 
     stub:
         """
-        touch deepvariant.snp_indel.vcf.gz
-        touch deepvariant.snp_indel.vcf.gz.tbi
-        touch deepvariant.snp_indel.g.vcf.gz
-        touch deepvariant.snp_indel.g.vcf.gz.tbi
+        touch snp_indel.vcf.gz
+        touch snp_indel.vcf.gz.tbi
         """
 
 }
 
-process publish_deepvariant {
-
-    publishDir "$outdir/$sample_id/$outdir2", mode: 'copy', overwrite: true, saveAs: { filename -> "$sample_id.$ref_name.$filename" }
-
-    input:
-        tuple val(sample_id), path(snp_indel_gvcf), path(snp_indel_gvcf_index)
-        val outdir
-        val outdir2
-        val ref_name
-
-    output:
-        val sample_id
-        path 'deepvariant.snp_indel.g.vcf.gz'
-        path 'deepvariant.snp_indel.g.vcf.gz.tbi'
-
-    script:
-        """
-        echo "Publishing files"
-        """
-
-    stub:
-        """
-        touch deepvariant.snp_indel.g.vcf.gz
-        touch deepvariant.snp_indel.g.vcf.gz.tbi
-        """
-
-}
-
-process whatshap_phase_dv {
+process whatshap_phase {
 
     input:
         tuple val(sample_id), val(data_type), path(bam), path(bam_index), path(snp_indel_vcf), path(snp_indel_vcf_index)
@@ -533,46 +409,47 @@ process whatshap_phase_dv {
         val ref_index
 
     output:
-        tuple val(sample_id), val(data_type), path(bam), path(bam_index), path('deepvariant.snp_indel.phased.vcf.gz'), path('deepvariant.snp_indel.phased.vcf.gz.tbi')
-        tuple val(sample_id), path('deepvariant.snp_indel.phased.vcf.gz'), path('deepvariant.snp_indel.phased.vcf.gz.tbi'), path('deepvariant.snp_indel.phased.read_list.txt')
+        tuple val(sample_id), val(data_type), path(bam), path(bam_index), path('snp_indel.phased.vcf.gz'), path('snp_indel.phased.vcf.gz.tbi')
+        tuple val(sample_id), path('snp_indel.phased.vcf.gz'), path('snp_indel.phased.vcf.gz.tbi'), path('snp_indel.phased.read_list.txt')
 
     script:
         """
         # run whatshap phase
         whatshap phase \
         --reference $ref \
-        --output deepvariant.snp_indel.phased.vcf.gz \
-        --output-read-list deepvariant.snp_indel.phased.read_list.txt \
+        --output snp_indel.phased.vcf.gz \
+        --output-read-list snp_indel.phased.read_list.txt \
         --sample $sample_id \
         --ignore-read-groups $snp_indel_vcf $bam
         # index vcf
-        tabix deepvariant.snp_indel.phased.vcf.gz
+        tabix snp_indel.phased.vcf.gz
         """
 
     stub:
         """
-        touch deepvariant.snp_indel.phased.vcf.gz
-        touch deepvariant.snp_indel.phased.vcf.gz.tbi
-        touch deepvariant.snp_indel.phased.read_list.txt
+        touch snp_indel.phased.vcf.gz
+        touch snp_indel.phased.vcf.gz.tbi
+        touch snp_indel.phased.read_list.txt
         """
 
 }
 
-process publish_whatshap_phase_dv {
+process publish_whatshap_phase {
 
-    publishDir "$outdir/$sample_id/$outdir2", mode: 'copy', overwrite: true, saveAs: { filename -> "$sample_id.$ref_name.$filename" }
+    publishDir "$outdir/$sample_id/$outdir2", mode: 'copy', overwrite: true, saveAs: { filename -> "$sample_id.$ref_name.$snp_indel_caller.$filename" }
 
     input:
         tuple val(sample_id), path(snp_indel_phased_vcf), path(snp_indel_phased_vcf_index), path(snp_indel_phased_read_list)
         val outdir
         val outdir2
         val ref_name
+        val snp_indel_caller
 
     output:
         val sample_id
-        path 'deepvariant.snp_indel.phased.vcf.gz'
-        path 'deepvariant.snp_indel.phased.vcf.gz.tbi'
-        path 'deepvariant.snp_indel.phased.read_list.txt'
+        path 'snp_indel.phased.vcf.gz'
+        path 'snp_indel.phased.vcf.gz.tbi'
+        path 'snp_indel.phased.read_list.txt'
 
     script:
         """
@@ -581,9 +458,102 @@ process publish_whatshap_phase_dv {
 
     stub:
         """
-        touch deepvariant.snp_indel.phased.vcf.gz
-        touch deepvariant.snp_indel.phased.vcf.gz.tbi
-        touch deepvariant.snp_indel.phased.read_list.txt
+        touch snp_indel.phased.vcf.gz
+        touch snp_indel.phased.vcf.gz.tbi
+        touch snp_indel.phased.read_list.txt
+        """
+
+}
+
+process vep_snv {
+
+    input:
+        tuple val(sample_id), path(snp_indel_phased_vcf), path(snp_indel_phased_vcf_index)
+        val ref
+        val ref_index
+        val vep_db
+        val revel_db
+        val gnomad_db
+        val clinvar_db
+        val cadd_snv_db
+        val cadd_indel_db
+        val cadd_sv_db
+        val spliceai_snv_db
+        val spliceai_indel_db
+        val alphamissense_db
+
+    output:
+        tuple val(sample_id), path('snp_indel.phased.annotated.vcf.gz'), path('snp_indel.phased.annotated.vcf.gz.tbi')
+
+    script:
+        """
+        # run vep
+        vep -i $snp_indel_phased_vcf \
+        -o snp_indel.phased.annotated.vcf.gz \
+        --format vcf \
+        --vcf \
+        --fasta $ref \
+        --dir $vep_db \
+        --assembly GRCh38 \
+        --species homo_sapiens \
+        --cache \
+        --offline \
+        --merged \
+        --sift b \
+        --polyphen b \
+        --symbol \
+        --hgvs \
+        --hgvsg \
+        --plugin REVEL,file=$revel_db \
+        --custom file=$gnomad_db,short_name=gnomAD,format=vcf,type=exact,fields=AF_joint%AF_exomes%AF_genomes%nhomalt_joint%nhomalt_exomes%nhomalt_genomes \
+        --custom file=$clinvar_db,short_name=ClinVar,format=vcf,type=exact,coords=0,fields=CLNSIG \
+        --plugin CADD,snv=$cadd_snv_db,indels=$cadd_indel_db \
+        --plugin SpliceAI,snv=$spliceai_snv_db,indel=$spliceai_indel_db \
+        --plugin AlphaMissense,file=$alphamissense_db \
+        --uploaded_allele \
+        --check_existing \
+        --filter_common \
+        --no_intergenic \
+        --pick \
+        --fork ${task.cpus} \
+        --no_stats \
+        --compress_output bgzip
+        # index vcf
+        tabix snp_indel.phased.annotated.vcf.gz
+        """
+
+    stub:
+        """
+        touch snp_indel.phased.annotated.vcf.gz
+        touch snp_indel.phased.annotated.vcf.gz.tbi
+        """
+
+}
+
+process publish_vep_snv {
+
+    publishDir "$outdir/$sample_id/$outdir2", mode: 'copy', overwrite: true, saveAs: { filename -> "$sample_id.$ref_name.$snp_indel_caller.$filename" }
+
+    input:
+        tuple val(sample_id), path(snp_indel_phased_annotated_vcf), path(snp_indel_phased_annotated_vcf_index)
+        val outdir
+        val outdir2
+        val ref_name
+        val snp_indel_caller
+
+    output:
+        path 'snp_indel.phased.annotated.vcf.gz'
+        path 'snp_indel.phased.annotated.vcf.gz.tbi'
+
+    script:
+        """
+        echo "Publishing files"
+        """
+
+    stub:
+        """
+        touch snp_indel.phased.annotated.vcf.gz
+        touch snp_indel.phased.annotated.vcf.gz.tbi
         """
 
 }
@@ -596,39 +566,41 @@ process whatshap_haplotag {
         val ref_index
 
     output:
-        tuple val(sample_id), val(data_type), path('minimap2.whatshap.sorted.haplotagged.bam'), path('minimap2.whatshap.sorted.haplotagged.bam.bai')
-        tuple val(sample_id), path('minimap2.whatshap.sorted.haplotagged.bam'), path('minimap2.whatshap.sorted.haplotagged.bam.bai'), path('minimap2.whatshap.sorted.haplotagged.tsv')
+        tuple val(sample_id), val(data_type), path('sorted.haplotagged.bam'), path('sorted.haplotagged.bam.bai')
+        tuple val(sample_id), path('sorted.haplotagged.bam'), path('sorted.haplotagged.bam.bai'), path('sorted.haplotagged.tsv')
 
     script:
         """
         # run whatshap haplotag
         whatshap haplotag \
         --reference $ref \
-        --output minimap2.whatshap.sorted.haplotagged.bam \
+        --output sorted.haplotagged.bam \
         --sample $sample_id \
         --tag-supplementary \
         --ignore-read-groups \
         --output-threads ${task.cpus} \
-        --output-haplotag-list minimap2.whatshap.sorted.haplotagged.tsv \
+        --output-haplotag-list sorted.haplotagged.tsv \
         $snp_indel_vcf $bam
         # index bam
         samtools index \
         -@ ${task.cpus} \
-        minimap2.whatshap.sorted.haplotagged.bam
+        sorted.haplotagged.bam
         """
 
     stub:
         """
-        touch minimap2.whatshap.sorted.haplotagged.bam
-        touch minimap2.whatshap.sorted.haplotagged.bam.bai
-        touch minimap2.whatshap.sorted.haplotagged.tsv
+        touch sorted.haplotagged.bam
+        touch sorted.haplotagged.bam.bai
+        touch sorted.haplotagged.tsv
         """
 
 }
 
 process publish_whatshap_haplotag {
 
-    publishDir "$outdir/$sample_id/$outdir2", mode: 'copy', overwrite: true, saveAs: { filename -> "$sample_id.$ref_name.$filename" }
+    def mapper_phaser = "minimap2.whatshap"
+
+    publishDir "$outdir/$sample_id/$outdir2", mode: 'copy', overwrite: true, saveAs: { filename -> "$sample_id.$ref_name.$mapper_phaser.$filename" }
 
     input:
         tuple val(sample_id), path(haplotagged_bam), path(haplotagged_bam_index), path(haplotagged_bam_tsv)
@@ -637,9 +609,9 @@ process publish_whatshap_haplotag {
         val ref_name
 
     output:
-        path 'minimap2.whatshap.sorted.haplotagged.bam'
-        path 'minimap2.whatshap.sorted.haplotagged.bam.bai'
-        path 'minimap2.whatshap.sorted.haplotagged.tsv'
+        path 'sorted.haplotagged.bam'
+        path 'sorted.haplotagged.bam.bai'
+        path 'sorted.haplotagged.tsv'
 
     script:
         """
@@ -648,9 +620,9 @@ process publish_whatshap_haplotag {
 
     stub:
         """
-        touch minimap2.whatshap.sorted.haplotagged.bam
-        touch minimap2.whatshap.sorted.haplotagged.bam.bai
-        touch minimap2.whatshap.sorted.haplotagged.tsv
+        touch sorted.haplotagged.bam
+        touch sorted.haplotagged.bam.bai
+        touch sorted.haplotagged.tsv
         """
 
 }
@@ -664,7 +636,7 @@ process sniffles {
         val tandem_repeat
 
     output:
-        tuple val(sample_id), path('sniffles.sv.phased.vcf.gz'), path('sniffles.sv.phased.vcf.gz.tbi'), path('sniffles.sv.phased.snf')
+        tuple val(sample_id), path('sv.phased.vcf.gz'), path('sv.phased.vcf.gz.tbi')
 
     script:
     // define a string to optionally pass tandem repeat bed file
@@ -676,8 +648,7 @@ process sniffles {
         --input $haplotagged_bam \
         --threads ${task.cpus} \
         --sample-id $sample_id \
-        --vcf sniffles.sv.phased.vcf.gz \
-        --snf sniffles.sv.phased.snf \
+        --vcf sv.phased.vcf.gz \
         --output-rnames \
         --minsvlen 20 \
         --phase $tandem_repeat_optional
@@ -685,27 +656,27 @@ process sniffles {
 
     stub:
         """
-        touch sniffles.sv.phased.vcf.gz
-        touch sniffles.sv.phased.vcf.gz.tbi
-        touch sniffles.sv.phased.snf
+        touch sv.phased.vcf.gz
+        touch sv.phased.vcf.gz.tbi
         """
 
 }
 
 process publish_sniffles {
 
-    publishDir "$outdir/$sample_id/$outdir2", mode: 'copy', overwrite: true, saveAs: { filename -> "$sample_id.$ref_name.$filename" }
+    def sv_caller = "sniffles"
+
+    publishDir "$outdir/$sample_id/$outdir2", mode: 'copy', overwrite: true, saveAs: { filename -> "$sample_id.$ref_name.$sv_caller.$filename" }
 
     input:
-        tuple val(sample_id), path(sv_vcf), path(sv_vcf_index), path(sv_snf)
+        tuple val(sample_id), path(sv_vcf), path(sv_vcf_index)
         val outdir
         val outdir2
         val ref_name
 
     output:
-        path 'sniffles.sv.phased.vcf.gz'
-        path 'sniffles.sv.phased.vcf.gz.tbi'
-        path 'sniffles.sv.phased.snf'
+        path 'sv.phased.vcf.gz'
+        path 'sv.phased.vcf.gz.tbi'
 
     script:
         """
@@ -714,9 +685,8 @@ process publish_sniffles {
 
     stub:
         """
-        touch sniffles.sv.phased.vcf.gz
-        touch sniffles.sv.phased.vcf.gz.tbi
-        touch sniffles.sv.phased.snf
+        touch sv.phased.vcf.gz
+        touch sv.phased.vcf.gz.tbi
         """
 
 }
@@ -730,7 +700,7 @@ process cutesv {
         val tandem_repeat
 
     output:
-        tuple val(sample_id), path('cutesv.sv.vcf.gz'), path('cutesv.sv.vcf.gz.tbi')
+        tuple val(sample_id), path('sv.vcf.gz'), path('sv.vcf.gz.tbi')
 
     script:
     if( data_type == 'ont' ) {
@@ -744,7 +714,7 @@ process cutesv {
         cuteSV \
         $haplotagged_bam \
         $ref \
-        cutesv.sv.vcf \
+        sv.vcf \
         ./ \
         --sample ${sample_id} \
         -t ${task.cpus} \
@@ -754,21 +724,23 @@ process cutesv {
         # compress and index vcf
         bgzip \
         -@ ${task.cpus} \
-        cutesv.sv.vcf
-        tabix cutesv.sv.vcf.gz
+        sv.vcf
+        tabix sv.vcf.gz
         """
 
     stub:
         """
-        touch cutesv.sv.vcf.gz
-        touch cutesv.sv.vcf.gz.tbi
+        touch sv.vcf.gz
+        touch sv.vcf.gz.tbi
         """
 
 }
 
 process publish_cutesv {
 
-    publishDir "$outdir/$sample_id/$outdir2", mode: 'copy', overwrite: true, saveAs: { filename -> "$sample_id.$ref_name.$filename" }
+    def sv_caller = "cutesv"
+
+    publishDir "$outdir/$sample_id/$outdir2", mode: 'copy', overwrite: true, saveAs: { filename -> "$sample_id.$ref_name.$sv_caller.$filename" }
 
     input:
         tuple val(sample_id), path(sv_vcf), path(sv_vcf_index)
@@ -777,8 +749,8 @@ process publish_cutesv {
         val ref_name
 
     output:
-        path 'cutesv.sv.vcf.gz'
-        path 'cutesv.sv.vcf.gz.tbi'
+        path 'sv.vcf.gz'
+        path 'sv.vcf.gz.tbi'
 
     script:
         """
@@ -787,8 +759,8 @@ process publish_cutesv {
 
     stub:
         """
-        touch cutesv.sv.vcf.gz
-        touch cutesv.sv.vcf.gz.tbi
+        touch sv.vcf.gz
+        touch sv.vcf.gz.tbi
         """
 
 }
@@ -802,8 +774,20 @@ workflow {
     tandem_repeat = "$params.tandem_repeat"
     snp_indel_caller = "$params.snp_indel_caller"
     sv_caller = "$params.sv_caller"
+    annotate = "$params.annotate"
+    annotate_override = "$params.annotate_override"
     outdir = "$params.outdir"
     outdir2 = "$params.outdir2"
+    vep_db = "$params.vep_db"
+    revel_db = "$params.revel_db"
+    gnomad_db = "$params.gnomad_db"
+    clinvar_db = "$params.clinvar_db"
+    cadd_snv_db = "$params.cadd_snv_db"
+    cadd_indel_db = "$params.cadd_indel_db"
+    cadd_sv_db = "$params.cadd_sv_db"
+    spliceai_snv_db = "$params.spliceai_snv_db"
+    spliceai_indel_db = "$params.spliceai_indel_db"
+    alphamissense_db = "$params.alphamissense_db"
 
     // check user provided parameters
     if ( !in_data ) {
@@ -829,6 +813,15 @@ workflow {
     }
     if ( sv_caller != 'sniffles' && sv_caller != 'cutesv' && sv_caller != 'both' ) {
         exit 1, "Error: SV calling software should be 'sniffles', 'cutesv', or 'both', '${sv_caller}' selected."
+    }
+    if ( !annotate ) {
+        exit 1, "Error: Choice to annotate not made. Either include in parameter file or pass to --annotate on the command line. Should be either 'yes' or 'no'."
+    }
+    if ( annotate != 'yes' && annotate != 'no' ) {
+        exit 1, "Error: Choice to annotate should be either 'yes', or 'no', '${annotate}' selected."
+    }
+    if ( annotate == 'yes' && !ref.toLowerCase().contains('hg38') && !ref.toLowerCase().contains('grch38') && annotate_override != 'yes' ) {
+        exit 1, "Warning: Annotation of only hg38/GRCh38 is supported. You've chosen to annotate, but it looks like you may not be passing a hg38/GRCh38 reference genome based on the filename of the reference genome. '${ref}' passed. Pass '--annotate_override yes' on the command line to override this error."
     }
     if ( !outdir ) {
         exit 1, "Error: No output directory provided. Either include in parameter file or pass to --outdir on the command line."
@@ -916,27 +909,27 @@ workflow {
     }
 
     // workflow
-    scrape_settings_to_publish = scrape_settings(in_data_tuple, in_data, ref, ref_index, tandem_repeat, snp_indel_caller, sv_caller, outdir)
+    scrape_settings_to_publish = scrape_settings(in_data_tuple, in_data, ref, ref_index, tandem_repeat, snp_indel_caller, sv_caller, annotate, outdir)
     publish_settings(scrape_settings_to_publish, outdir, outdir2, ref_name)
     bam_header = scrape_bam_header(in_data_list)
     publish_bam_header(bam_header, outdir, outdir2)
     merged = merge_runs(in_data_tuple)
     (bam, minimap_to_publish1) = minimap2(merged, ref, ref_index)
     minimap_to_publish2 = depth(minimap_to_publish1)
-    publish_minimap2(minimap_to_publish2, outdir, outdir2, ref_name)
+    publish_depth(minimap_to_publish2, outdir, outdir2, ref_name)
     if ( snp_indel_caller == 'clair3' ) {
-        (snp_indel_vcf, clair3_to_publish) = clair3(bam, ref, ref_index)
-        publish_clair3(clair3_to_publish, outdir, outdir2, ref_name)
-        (snp_indel_phased_vcf, whatshap_phase_to_publish) = whatshap_phase_clair3(snp_indel_vcf, ref, ref_index)
-        publish_whatshap_phase_clair3(whatshap_phase_to_publish, outdir, outdir2, ref_name)
+        (snp_indel_vcf_bam, snp_indel_vcf) = clair3(bam, ref, ref_index)
     }
     else if ( snp_indel_caller == 'deepvariant' ) {
-        (snp_indel_vcf, deepvariant_to_publish) = deepvariant(bam, ref, ref_index)
-        publish_deepvariant(deepvariant_to_publish, outdir, outdir2, ref_name)
-        (snp_indel_phased_vcf, whatshap_phase_to_publish) = whatshap_phase_dv(snp_indel_vcf, ref, ref_index)
-        publish_whatshap_phase_dv(whatshap_phase_to_publish, outdir, outdir2, ref_name)
+        (snp_indel_vcf_bam, snp_indel_vcf) = deepvariant(bam, ref, ref_index)
     }
-    (haplotagged_bam, whatshap_haplotag_to_publish) = whatshap_haplotag(snp_indel_phased_vcf, ref, ref_index)
+    (snp_indel_phased_vcf_bam, snp_indel_phased_vcf) = whatshap_phase(snp_indel_vcf_bam, ref, ref_index)
+    publish_whatshap_phase(snp_indel_phased_vcf, outdir, outdir2, ref_name, snp_indel_caller)
+    if ( annotate == 'yes' ) {
+        vep_snv_to_publish = vep_snv(snp_indel_phased_vcf, ref, ref_index, vep_db, revel_db, gnomad_db, clinvar_db, cadd_snv_db, cadd_indel_db, cadd_sv_db, spliceai_snv_db, spliceai_indel_db, alphamissense_db)
+        publish_vep_snv(vep_snv_to_publish, outdir, outdir2, ref_name, snp_indel_caller)
+    }
+    (haplotagged_bam, whatshap_haplotag_to_publish) = whatshap_haplotag(snp_indel_phased_vcf_bam, ref, ref_index)
     publish_whatshap_haplotag(whatshap_haplotag_to_publish, outdir, outdir2, ref_name)
     if ( sv_caller == 'sniffles' ) {
         sniffles_to_publish = sniffles(haplotagged_bam, ref, ref_index, tandem_repeat)

--- a/pipeface.nf
+++ b/pipeface.nf
@@ -872,8 +872,20 @@ workflow {
     if ( !deepvariant_container ) {
         exit 1, "Error: No DeepVariant container provided. Either include in parameter file or pass to --deepvariant_container on the command line. Set to 'NONE' if not running DeepVariant."
     }
-    if ( deepvariant_container != 'NONE' && snp_indel_caller == 'clair3') {
-        exit 1, "Error: Pass 'NONE' to 'deepvariant_container' when DeepVariant is NOT selected as the SNP/indel calling software, '${snp_indel_caller}' and '${deepvariant_container}' provided'."
+    if ( deepvariant_container != 'NONE' && snp_indel_caller != 'deepvariant') {
+        exit 1, "Error: Pass 'NONE' to 'deepvariant_container' when DeepVariant is NOT selected as the SNP/indel calling software, '${deepvariant_container}' and '${snp_indel_caller}' respectively provided'."
+    }
+    if ( deepvariant_container == 'NONE' && snp_indel_caller == 'deepvariant') {
+        exit 1, "Error: Pass an appropriate path to 'deepvariant_container' when DeepVariant is selected as the SNP/indel calling software, '${deepvariant_container}' and '${snp_indel_caller}' respectively provided'."
+    }
+    if ( !mosdepth_binary ) {
+        exit 1, "Error: No mosdepth binary provided. Either include in parameter file or pass to --mosdepth_binary on the command line. Set to 'NONE' if not running depth calculation."
+    }
+    if ( mosdepth_binary != 'NONE' && calculate_depth == 'no') {
+        exit 1, "Error: Pass 'NONE' to 'mosdepth_binary' when choosing to NOT calculate depth, '${mosdepth_binary}' and '${calculate_depth}' respectively provided'."
+    }
+    if ( mosdepth_binary == 'NONE' && calculate_depth == 'yes') {
+        exit 1, "Error: Pass an appropriate path to 'mosdepth_binary' when choosing to calculate depth, '${mosdepth_binary}' and '${calculate_depth}' respectively provided'."
     }
     if ( !file(in_data).exists() ) {
         exit 1, "Error: In data csv file path does not exist, '${in_data}' provided."
@@ -888,7 +900,10 @@ workflow {
         exit 1, "Error: Tandem repeat bed file path does not exist, '${tandem_repeat}' provided."
     }
     if ( !file(deepvariant_container).exists() ) {
-        exit 1, "Error: In DeepVariant container file path does not exist, '${deepvariant_container}' provided."
+        exit 1, "Error: DeepVariant container file path does not exist, '${deepvariant_container}' provided."
+    }
+    if ( !file(mosdepth_binary).exists() ) {
+        exit 1, "Error: mosdepth binary file path does not exist, '${mosdepth_binary}' provided."
     }
 
     // build variable

--- a/pipeface.nf
+++ b/pipeface.nf
@@ -265,6 +265,7 @@ process mosdepth {
 
     input:
         tuple val(sample_id), val(regions_of_interest), path(bam), path(bam_index)
+        val mosdepth_binary
 
     output:
         tuple val(sample_id), path('depth.txt')
@@ -274,7 +275,7 @@ process mosdepth {
     def regions_of_interest_optional = file(regions_of_interest).name != 'NONE' ? "-b $regions_of_interest" : ''
         """
         # run mosdepth
-        /g/data/ox63/install/mosdepth_v0.3.9 \
+        $mosdepth_binary \
         depth \
         $bam \
         $regions_of_interest_optional \
@@ -782,6 +783,7 @@ workflow {
     outdir = "$params.outdir"
     outdir2 = "$params.outdir2"
     deepvariant_container = "$params.deepvariant_container"
+    mosdepth_binary = "$params.mosdepth_binary"
     vep_db = "$params.vep_db"
     revel_db = "$params.revel_db"
     gnomad_db = "$params.gnomad_db"
@@ -964,7 +966,7 @@ workflow {
     merged = merge_runs(in_data_tuple)
     (bam, minimap_to_publish1) = minimap2(merged, ref, ref_index)
     if ( calculate_depth == 'yes' ) {
-        minimap_to_publish2 = mosdepth(minimap_to_publish1)
+        minimap_to_publish2 = mosdepth(minimap_to_publish1, mosdepth_binary)
         publish_mosdepth(minimap_to_publish2, outdir, outdir2, ref_name)
     }
     if ( snp_indel_caller == 'clair3' ) {


### PR DESCRIPTION
Transition from calculating depth with [samtools depth](https://www.htslib.org/doc/samtools-depth.html) to [mosdepth](https://github.com/brentp/mosdepth). The main reason for the switch is to avoid re-writing what mosdepth already handles, calculating depth in the case of targeted sequencing (where we'd want to pass a regions of interest bed file and additionally obtain the depth for these regions only, rather than only providing the depth for the whole chromosome).