### PR TITLE
Cohort extend2

### DIFF
--- a/config/nextflow_pipeface.config
+++ b/config/nextflow_pipeface.config
@@ -126,10 +126,18 @@ process {
         module = 'singularity:htslib/1.16:ensemblorg/ensembl-vep/release_112.0'
     }
 
-    withName: 'whatshap_phase|whatshap_haplotag|whatshap_joint_phase' {
+    withName: 'whatshap_phase|whatshap_haplotag' {
         queue = 'normal'
         cpus = '4'
         time = '10h'
+        memory = '16GB'
+        module = 'whatshap/2.3:htslib/1.16:samtools/1.19'
+    }
+
+    withName: whatshap_joint_phase {
+        queue = 'normal'
+        cpus = '4'
+        time = '24h'
         memory = '16GB'
         module = 'whatshap/2.3:htslib/1.16:samtools/1.19'
     }


### PR DESCRIPTION
- Fix sort of joint jasmine SV VCF, which affected the VCF header (order of VCF header and cause overwrite of jasmine INFO tags during downstream annotation)
- Strip prefixes jamines appends to sample ID's in joint SV VCF files
- Publish individual SNP/indel and SV VCF's in cohort/deeptrio mode
- Add 'jasmine' in the joint SV VCF for clarity that it's a joint VCF
- Add more walltime for joint phase