### PR TITLE
Env modules

### DIFF
--- a/config/nextflow_pipeface.config
+++ b/config/nextflow_pipeface.config
@@ -64,6 +64,7 @@ process {
         cpus = '8'
         time = '2h'
         memory = '32GB'
+        module = 'mosdepth/0.3.9'
     }
 
     withName: clair3 {
@@ -191,6 +192,7 @@ process {
         cpus = '48'
         time = '2h'
         memory = '192GB'
+        module 'pb-CpG-tools/2.3.2'
     }
 
     withName: sniffles {

--- a/config/parameters_pipeface.json
+++ b/config/parameters_pipeface.json
@@ -11,9 +11,7 @@
     "annotate": "",
     "calculate_depth": "",
     "analyse_base_mods": "",
-    "outdir": "",
-    "mosdepth_binary": "",
-    "pbcpgtools_binary": ""
+    "outdir": ""
 
 }
 

--- a/docs/run_on_nci.md
+++ b/docs/run_on_nci.md
@@ -9,8 +9,6 @@
     - [Clair3 models (if running clair3)](#clair3-models-if-running-clair3)
       - [ONT](#ont)
       - [Pacbio HiFi revio](#pacbio-hifi-revio)
-    - [mosdepth binary (if running depth calculation)](#mosdepth-binary-if-running-depth-calculation)
-    - [pb-CpG-tools binary (if processing pacbio data)](#pb-cpg-tools-binary-if-processing-pacbio-data)
   - [3. Modify in\_data.csv](#3-modify-in_datacsv)
     - [Singleton mode](#singleton-mode)
     - [Cohort mode](#cohort-mode)
@@ -118,24 +116,6 @@ Untar
 
 ```bash
 tar -xvf hifi_revio.tar.gz
-```
-
-### mosdepth binary (if running depth calculation)
-
-Get a local copy of the mosdepth v0.3.9 binary
-
-```bash
-wget https://github.com/brentp/mosdepth/releases/download/v0.3.9/mosdepth -O mosdepth_0.3.9
-chmod +x mosdepth_0.3.9
-```
-
-### pb-CpG-tools binary (if processing pacbio data)
-
-Get a local copy of the pb-CpG-tools v2.3.2 binary
-
-```bash
-wget https://github.com/PacificBiosciences/pb-CpG-tools/releases/download/v2.3.2/pb-CpG-tools-v2.3.2-x86_64-unknown-linux-gnu.tar.gz
-tar -xzf pb-CpG-tools-v2.3.2-x86_64-unknown-linux-gnu.tar.gz
 ```
 
 ## 3. Modify in_data.csv
@@ -330,30 +310,6 @@ Specify the directory in which to write the pipeline outputs (please provide a f
 
 ```json
     "outdir": "/g/data/ox63/results"
-```
-
-Specify the path to the mosdepth binary (if running depth calculation). Eg:
-
-```json
-    "mosdepth_binary": "./mosdepth_0.3.9"
-```
-
-*OR*
-
-```json
-    "mosdepth_binary": "NONE"
-```
-
-Specify the path to the pb-CpG-tools binary (if processing pacbio data). Eg:
-
-```json
-    "pbcpgtools_binary": "./pb-CpG-tools-v2.3.2-x86_64-unknown-linux-gnu/"
-```
-
-*OR*
-
-```json
-    "pbcpgtools_binary": "NONE"
 ```
 
 ## 6. Start persistent session (optional)

--- a/pipeface.nf
+++ b/pipeface.nf
@@ -253,7 +253,6 @@ process mosdepth {
 
     input:
         tuple val(sample_id), val(family_id), path(bam), val(regions_of_interest)
-        val mosdepth_binary
         val outdir
         val outdir2
         val ref_name
@@ -272,7 +271,7 @@ process mosdepth {
         ln -sf \${bam_loc}.bai .
         ln -sf \${bam_loc}.bai sorted.bam.bai
         # run mosdepth
-        $mosdepth_binary \
+        mosdepth \
         depth \
         $bam \
         $regions_of_interest_optional \
@@ -1036,7 +1035,6 @@ process pbcpgtools {
 
     input:
         tuple val(sample_id), val(family_id), path(haplotagged_bam), path(haplotagged_bam_index), val(data_type)
-        val pbcpgtools_binary
         val ref
         val ref_index
         val outdir
@@ -1050,7 +1048,7 @@ process pbcpgtools {
     if( data_type == 'pacbio' )
         """
         # run pb-cpg-tools
-        $pbcpgtools_binary/bin/aligned_bam_to_cpg_scores \
+        aligned_bam_to_cpg_scores \
         --bam $haplotagged_bam \
         --ref $ref \
         --pileup-mode model \
@@ -1502,8 +1500,6 @@ workflow {
     analyse_base_mods = "$params.analyse_base_mods"
     outdir = "$params.outdir"
     outdir2 = "$params.outdir2"
-    mosdepth_binary = "$params.mosdepth_binary"
-    pbcpgtools_binary = "$params.pbcpgtools_binary"
     vep_db = "$params.vep_db"
     revel_db = "$params.revel_db"
     gnomad_db = "$params.gnomad_db"
@@ -1655,24 +1651,6 @@ workflow {
     if ( !outdir ) {
         exit 1, "No output directory provided. Either include in parameter file or pass to --outdir on the command line."
     }
-    if ( !mosdepth_binary ) {
-        exit 1, "No mosdepth binary provided. Either include in parameter file or pass to --mosdepth_binary on the command line. Set to 'NONE' if not running depth calculation."
-    }
-    if ( mosdepth_binary != 'NONE' && calculate_depth == 'no') {
-        exit 1, "Pass 'NONE' to 'mosdepth_binary' when choosing to NOT calculate depth, '${mosdepth_binary}' and '${calculate_depth}' respectively provided'."
-    }
-    if ( mosdepth_binary == 'NONE' && calculate_depth == 'yes') {
-        exit 1, "Pass an appropriate path to 'mosdepth_binary' when choosing to calculate depth, '${mosdepth_binary}' and '${calculate_depth}' respectively provided'."
-    }
-    if ( !pbcpgtools_binary ) {
-        exit 1, "No pb-CpG-tools binary provided. Either include in parameter file or pass to --pbcpgtools_binary on the command line. Set to 'NONE' if not analysing any pacbio data."
-    }
-    if ( in_data_format == 'snv_vcf' && pbcpgtools_binary != 'NONE' ) {
-        exit 1, "When the input data format is 'snv_vcf', please set the pb-CpG-tools binary (pbcpgtools_binary) to 'NONE'."
-    }
-    if ( in_data_format == 'sv_vcf' && pbcpgtools_binary != 'NONE' ) {
-        exit 1, "When the input data format is 'sv_vcf', please set the pb-CpG-tools binary (pbcpgtools_binary) to 'NONE'."
-    }
     if ( !file(in_data).exists() ) {
         exit 1, "In data csv file path does not exist, '${in_data}' provided."
     }
@@ -1684,9 +1662,6 @@ workflow {
     }
     if ( !file(tandem_repeat).exists() ) {
         exit 1, "Tandem repeat bed file path does not exist, '${tandem_repeat}' provided."
-    }
-    if ( !file(mosdepth_binary).exists() ) {
-        exit 1, "mosdepth binary file path does not exist, '${mosdepth_binary}' provided."
     }
 
     // build variable
@@ -1864,7 +1839,7 @@ workflow {
     }
     if ( in_data_format == 'ubam_fastq' | in_data_format == 'aligned_bam' ) {
         if ( calculate_depth == 'yes' ) {
-            mosdepth(bam.join(regions_of_interest_tuple, by: [0,1]), mosdepth_binary, outdir, outdir2, ref_name)
+            mosdepth(bam.join(regions_of_interest_tuple, by: [0,1]), outdir, outdir2, ref_name)
         }
         // snp/indel calling
         if ( snp_indel_caller == 'clair3' ) {
@@ -1885,7 +1860,7 @@ workflow {
         // methylation analysis
         if ( analyse_base_mods == 'yes' ) {
             minimod(haplotagged_bam.join(data_type_tuple, by: [0,1]), ref, ref_index, outdir, outdir2, ref_name)
-            pbcpgtools(haplotagged_bam.join(data_type_tuple, by: [0,1]), pbcpgtools_binary, ref, ref_index, outdir, outdir2, ref_name)
+            pbcpgtools(haplotagged_bam.join(data_type_tuple, by: [0,1]), ref, ref_index, outdir, outdir2, ref_name)
         }
         // joint snp/indel calling
         if ( snp_indel_caller == 'deeptrio' ) {

--- a/pipeface.nf
+++ b/pipeface.nf
@@ -1052,7 +1052,7 @@ process pbcpgtools {
         --bam $haplotagged_bam \
         --ref $ref \
         --pileup-mode model \
-        --model $pbcpgtools_binary/models/pileup_calling_model.v1.tflite \
+        --model /g/data/if89/apps/pb-CpG-tools/2.3.2/pileup_calling_model.v1.tflite \
         --modsites-mode denovo \
         --hap-tag HP \
         --threads ${task.cpus}


### PR DESCRIPTION
Use environmental modules for mosdepth and pb-CpG-tools instead of requiring the user to define their binaries in parameters_pipeface.json