### PR TITLE
Fix iris arguments for jasmine cutesv

### DIFF
--- a/pipeface.nf
+++ b/pipeface.nf
@@ -1460,7 +1460,7 @@ process jasmine_cutesv {
             iris_args = '--run_iris iris_args=min_ins_length=20,--rerunracon,--keep_long_variants'
         }
         else if( proband_data_type == 'pacbio' ) {
-            iris_args = '--run_iris iris_args=min_ins_length=20,--rerunracon,--keep_long_variants,--hifi'
+            iris_args = '--run_iris iris_args=min_ins_length=20,--rerunracon,--keep_long_variants,--pacbio'
         }
         """
         # unzip vcfs


### PR DESCRIPTION
Fix iris arguments for jasmine cutesv process (it's still using `--hifi` instead of `--pacbio`)